### PR TITLE
scoresaber regex instead of .replace()

### DIFF
--- a/src/main/java/bot/api/ApiConstants.java
+++ b/src/main/java/bot/api/ApiConstants.java
@@ -4,6 +4,7 @@ public class ApiConstants {
 
 	// ScoreSaber
 	public static String USER_PRE_URL = "https://scoresaber.com/u/";
+	public static final String USER_ID_REGEX = "scoresaber\\.com\\/u\\/(\\d+)";
 
 	public static String SS_PRE_URL = "https://new.scoresaber.com";
 	public static String SS_PLAYER_PRE_URL = SS_PRE_URL + "/api/player/";

--- a/src/main/java/bot/main/BeatSaberBot.java
+++ b/src/main/java/bot/main/BeatSaberBot.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.security.auth.login.LoginException;
@@ -432,8 +434,12 @@ public class BeatSaberBot extends ListenerAdapter {
 		System.out.println("Ready!");
 	}
 
+	Pattern scoreSaberIDPattern = Pattern.compile(ApiConstants.USER_ID_REGEX);
+
 	private Player getScoreSaberPlayerFromUrl(String profileUrl) throws FileNotFoundException {
-		String playerId = profileUrl.replace(ApiConstants.USER_PRE_URL, "");
+		Matcher matcher = scoreSaberIDPattern.matcher(profileUrl);
+		if(!matcher.find()) throw new FileNotFoundException("Player could not be found, invalid link!");
+		String playerId = matcher.group(1);
 		Player player = ss.getPlayerById(playerId);
 		if (player == null) {
 			throw new FileNotFoundException("Player could not be found!");


### PR DESCRIPTION
no more .replace()
handles the following links as well as the default one, instead of not working at all:
- `https://www.scoresaber.com/u/<id>`
- `http://www.scoresaber.com/u/<id>`

RegEx: `scoresaber\.com\/u\/(\d+)`