### PR TITLE
Fix BSG milestone roles flapping (remove/re-add same role every refresh)

### DIFF
--- a/src/main/java/bot/main/LeaderboardWatcher.java
+++ b/src/main/java/bot/main/LeaderboardWatcher.java
@@ -3,7 +3,6 @@ package bot.main;
 import bot.api.ScoreSaber;
 import bot.db.DatabaseManager;
 import bot.dto.player.DataBasePlayer;
-import bot.roles.RoleManager;
 import bot.roles.RoleManagerBSG;
 import bot.utils.DiscordLogger;
 import bot.utils.Format;
@@ -114,23 +113,22 @@ public class LeaderboardWatcher {
             //Role change
             boolean isInactive = updatedPlayer.getCountryRank() == 0;
             Member member = bsgMembers.stream().filter(m -> m.getIdLong() == updatedPlayer.getDiscordUserId()).findFirst().orElse(null);
-            if (member != null && RoleManagerBSG.isNewMilestone(updatedPlayer.getCountryRank(), member)) {
-                //Remove all "Top "... bot.roles
-                RoleManager.removeMemberRolesByName(member, BotConstants.topRolePrefix);
-                if (!isInactive) {
+            if (member != null) {
+                // Idempotent: only changes roles when the member doesn't already hold the correct
+                // milestone role. Returns true only when a new milestone role was actually added,
+                // which stops the endless add/remove role flapping on every refresh.
+                boolean reachedNewMilestone = RoleManagerBSG.syncMilestoneRole(member, updatedPlayer.getCountryRank(), isInactive);
+                if (reachedNewMilestone) {
                     //Log
                     System.out.println("Updating member: "+member.getEffectiveName());
                     int milestone = ListValueUtils.findBsgMilestoneForRank(updatedPlayer.getCountryRank());
                     String newRoleMessage = "Changed BSG role: " + updatedPlayer.getName() + " New Rank: " + updatedPlayer.getCountryRank() + " - Old Rank: " + oldPlayer.getCountryRank() + "   " + "(Top " + milestone + ")";
                     DiscordLogger.sendLogInChannel(newRoleMessage, DiscordLogger.WATCHER_REFRESH);
 
-                    //Add "Top xxx DE" role
-                    RoleManagerBSG.assignMilestoneRole(updatedPlayer.getCountryRank(), member);
                     if (updatedPlayer.getCountryRank() < oldPlayer.getCountryRank()) {
                         Messages.sendBsgRankMessage("🎉 " + Format.bold(Format.underline(updatedPlayer.getName())) + " is now part of the " + Format.underline("Top " + milestone) + " in Germany! Congrats! 🎉", "", updatedPlayer.getProfileURL(), Color.RED, updatedPlayer.getProfilePicture(), bsgOutput);
                     }
                 }
-
             }
             //Snipe Channel
             boolean playerImproved = updatedPlayer.getCountryRank() < oldPlayer.getCountryRank() && updatedPlayer.getPp() != oldPlayer.getPp();

--- a/src/main/java/bot/roles/RoleManager.java
+++ b/src/main/java/bot/roles/RoleManager.java
@@ -9,8 +9,11 @@ import java.util.stream.Collectors;
 
 public class RoleManager {
     public static void removeMemberRolesByName(Member member, String name) {
-        List<Role> milestoneRoles = getMemberRolesByName(member, name);
-        for (Role role : milestoneRoles) {
+        removeMemberRoles(member, getMemberRolesByName(member, name));
+    }
+
+    public static void removeMemberRoles(Member member, List<Role> roles) {
+        for (Role role : roles) {
             try {
                 member.getGuild().removeRoleFromMember(member, role).queue();
             } catch (Exception e) {

--- a/src/main/java/bot/roles/RoleManagerBSG.java
+++ b/src/main/java/bot/roles/RoleManagerBSG.java
@@ -6,25 +6,103 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class RoleManagerBSG {
 
-    public static boolean isNewMilestone(int countryRank, Member member) {
-        int minBsgCountryRank = BotConstants.bsgCountryRankMilestones[BotConstants.bsgCountryRankMilestones.length - 1];
-        if (member == null || countryRank > minBsgCountryRank) {
+    private static final String DE_SUFFIX = " DE";
+
+    /**
+     * Ensures the member holds exactly the milestone role that matches their current country rank.
+     * <p>
+     * This is idempotent: if the member already has the correct role (and no other milestone roles),
+     * nothing is touched. This is the fix for the endless "removed Top X DE / added Top X DE" role
+     * flapping that happened every refresh cycle.
+     *
+     * The previous implementation relied on a case-sensitive {@code equals} check to decide whether a
+     * change was needed, while the actual add/remove used case-insensitive matching. Whenever the Discord
+     * role name did not byte-for-byte match {@code "Top <n> DE"} (different casing, a stray space, or an
+     * extra unrelated "Top ..." role the bot could not remove), the check kept reporting "new milestone"
+     * forever and the bot removed and re-added the same role on every run.
+     *
+     * @param member      the guild member to update
+     * @param countryRank the player's current ScoreSaber country rank (0 = inactive)
+     * @param isInactive  whether the player is currently inactive
+     * @return {@code true} only if the target milestone role was newly added (i.e. the member actually
+     * reached a milestone they did not have before) — used to decide logging / congrats messages
+     */
+    public static boolean syncMilestoneRole(Member member, int countryRank, boolean isInactive) {
+        if (member == null) {
             return false;
         }
-        int milestone = ListValueUtils.findBsgMilestoneForRank(countryRank);
-        Role milestoneRole = member.getRoles().stream()
-                .filter(role -> role.getName().equals(BotConstants.topRolePrefix + milestone + " DE"))
-                .findFirst()
-                .orElse(null);
-        List<Role> milestoneRoles = RoleManager.getMemberRolesByName(member, BotConstants.topRolePrefix);
-        return milestoneRole == null || milestoneRoles.size() > 1;
+        String targetRole = isInactive ? null : getMilestoneRoleName(countryRank);
+
+        // Active player whose rank is below the lowest tracked milestone: leave their roles untouched
+        // (matches the original behaviour of doing nothing once a player drops out of the milestone range).
+        if (!isInactive && targetRole == null) {
+            return false;
+        }
+
+        List<Role> currentMilestoneRoles = getCurrentMilestoneRoles(member);
+        boolean hasTarget = targetRole != null
+                && currentMilestoneRoles.stream().anyMatch(role -> namesMatch(role.getName(), targetRole));
+
+        // Strip any milestone role that is not the target (stale milestones, wrong casing, duplicates).
+        List<Role> staleRoles = currentMilestoneRoles.stream()
+                .filter(role -> targetRole == null || !namesMatch(role.getName(), targetRole))
+                .collect(Collectors.toList());
+        if (!staleRoles.isEmpty()) {
+            RoleManager.removeMemberRoles(member, staleRoles);
+        }
+
+        // Only add the target role if it is genuinely missing -> no remove-then-re-add churn.
+        if (targetRole != null && !hasTarget) {
+            RoleManager.assignRole(member, targetRole);
+            return true;
+        }
+        return false;
     }
 
-    public static void assignMilestoneRole(int countryRank, Member member) {
+    /**
+     * @return the "Top &lt;n&gt; DE" role name the given country rank maps to, or {@code null} if the rank
+     * is outside the tracked milestone range.
+     */
+    public static String getMilestoneRoleName(int countryRank) {
+        int lowestMilestone = BotConstants.bsgCountryRankMilestones[BotConstants.bsgCountryRankMilestones.length - 1];
+        if (countryRank <= 0 || countryRank > lowestMilestone) {
+            return null;
+        }
         int milestone = ListValueUtils.findBsgMilestoneForRank(countryRank);
-        RoleManager.assignRole(member, BotConstants.topRolePrefix + milestone + " DE");
+        if (milestone < 0) {
+            return null;
+        }
+        return BotConstants.topRolePrefix + milestone + DE_SUFFIX;
+    }
+
+    /**
+     * @return all "Top &lt;n&gt; DE" milestone roles the member currently holds. Unlike a broad
+     * {@code contains("top ")} match, this only matches the actual BSG milestone roles, so unrelated
+     * roles that merely contain "top" are never removed or counted.
+     */
+    public static List<Role> getCurrentMilestoneRoles(Member member) {
+        return member.getRoles().stream()
+                .filter(role -> isMilestoneRoleName(role.getName()))
+                .collect(Collectors.toList());
+    }
+
+    private static boolean isMilestoneRoleName(String roleName) {
+        if (roleName == null) {
+            return false;
+        }
+        for (Integer milestone : BotConstants.bsgCountryRankMilestones) {
+            if (namesMatch(roleName, BotConstants.topRolePrefix + milestone + DE_SUFFIX)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean namesMatch(String a, String b) {
+        return a != null && b != null && a.trim().equalsIgnoreCase(b.trim());
     }
 }


### PR DESCRIPTION
## Problem

On the BSG (Beat Saber Germany) server the bot removes and immediately re-adds the **same** `Top <n> DE` milestone role to the **same** member on every 20-minute refresh — forever. The audit log fills with entries like:

```
removed role  Top 100 DE
added role    Top 100 DE
removed role  Top 100 DE
added role    Top 100 DE
...
```

even though the player's rank never changed.

## Root cause

`RoleManagerBSG.isNewMilestone(...)` decided whether a role change was needed with a **case-sensitive** check:

```java
member.getRoles().stream()
    .filter(role -> role.getName().equals(BotConstants.topRolePrefix + milestone + " DE"))
```

…but the add and remove paths are **case-insensitive**:

- add → `guild.getRolesByName(roleName, true)` (ignoreCase = true)
- remove → `role.getName().toLowerCase().contains(name.toLowerCase())`

So whenever a member's role name didn't match the computed string byte-for-byte — a different casing, a stray trailing space, or an unrelated extra `Top ...` role the bot couldn't remove (which makes `milestoneRoles.size() > 1` permanently true) — `isNewMilestone` returned `true` on **every** cycle, and `LeaderboardWatcher` dutifully removed all `Top ` roles and re-added the milestone role each time.

## Fix

Replace the broken guard with an idempotent reconcile, `RoleManagerBSG.syncMilestoneRole(member, countryRank, isInactive)`:

- matches milestone roles **case-insensitively and trimmed**, and only against the real `Top <n> DE` names (no longer matches any role that merely contains `"top "`);
- if the member already holds exactly the correct role, **does nothing**;
- otherwise removes only the *stale* milestone roles and adds the target only if it's actually missing — no remove-then-re-add churn;
- returns `true` only when a milestone role was genuinely added, so the existing log line and the "🎉 … is now part of the Top N in Germany!" congrats message still fire exactly when a player reaches a new milestone.

Behaviour is otherwise unchanged: inactive players still get their milestone roles stripped, and players below the lowest tracked milestone are left untouched.

## Testing

The three changed files compile cleanly (`javac`, Java 8) against the deployed bot's dependencies. The change is logic-local to milestone role handling; no API/DB/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
