### PR TITLE
Handle ScoreSaber rate limiting (429 backoff + correct request spacing)

### DIFF
--- a/src/main/java/bot/api/HttpMethods.java
+++ b/src/main/java/bot/api/HttpMethods.java
@@ -4,6 +4,7 @@ import bot.utils.DiscordLogger;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
 import org.apache.commons.httpclient.cookie.CookiePolicy;
@@ -22,6 +23,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.*;
 
 public class HttpMethods {
+
+    private static final int TOO_MANY_REQUESTS = 429;
+    private static final int MAX_RETRIES = 4;
 
     final HttpClient http;
 
@@ -56,22 +60,71 @@ public class HttpMethods {
     }
 
     public InputStream get(String url) throws IOException {
-        GetMethod get = new GetMethod(url);
-        setAgent(get);
-        int statusCode = http.executeMethod(get);
-        if (statusCode != 200) {
+        int attempt = 0;
+        while (true) {
+            GetMethod get = new GetMethod(url);
+            setAgent(get);
+            int statusCode = http.executeMethod(get);
+
+            if (statusCode == 200) {
+                InputStream response = null;
+                try {
+                    response = get.getResponseBodyAsStream();
+                } catch (IOException e) {
+                    closeStream(response);
+                    DiscordLogger.sendLogInChannel(e.getMessage(), DiscordLogger.HTTP_ERRORS);
+                }
+                return response;
+            }
+
+            // ScoreSaber (and other APIs) answer with 429 when rate limited. Respect the
+            // Retry-After / X-RateLimit-Reset headers and retry instead of silently dropping the
+            // player for this refresh cycle.
+            if (statusCode == TOO_MANY_REQUESTS && attempt < MAX_RETRIES) {
+                long waitMs = retryDelayMillis(get, attempt);
+                get.releaseConnection();
+                attempt++;
+                try {
+                    Thread.sleep(waitMs);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return null;
+                }
+                continue;
+            }
+
             DiscordLogger.sendLogInChannel("Data could not be fetched. (" + url + ")\nStatuscode: " + statusCode, DiscordLogger.HTTP_ERRORS);
+            get.releaseConnection();
             return null;
         }
+    }
 
-        InputStream response = null;
-        try {
-            response = get.getResponseBodyAsStream();
-        } catch (IOException e) {
-            closeStream(response);
-            DiscordLogger.sendLogInChannel(e.getMessage(), DiscordLogger.HTTP_ERRORS);
+    private long retryDelayMillis(GetMethod get, int attempt) {
+        long seconds = headerSeconds(get, "Retry-After");
+        if (seconds <= 0) {
+            seconds = headerSeconds(get, "X-RateLimit-Reset-Short");
         }
-        return response;
+        if (seconds <= 0) {
+            seconds = headerSeconds(get, "X-RateLimit-Reset-Medium");
+        }
+        if (seconds <= 0) {
+            // Exponential backoff fallback: 1s, 2s, 4s, ...
+            return 1000L * (1L << attempt);
+        }
+        // Small cushion so we come back just after the window has reset.
+        return Math.max(1000L, seconds * 1000L + 250L);
+    }
+
+    private long headerSeconds(GetMethod get, String name) {
+        Header header = get.getResponseHeader(name);
+        if (header == null || header.getValue() == null) {
+            return 0;
+        }
+        try {
+            return Long.parseLong(header.getValue().trim());
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     public JsonObject fetchJsonObject(String url) {

--- a/src/main/java/bot/main/LeaderboardWatcher.java
+++ b/src/main/java/bot/main/LeaderboardWatcher.java
@@ -24,6 +24,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class LeaderboardWatcher {
+    // Keeps sustained polling under ScoreSaber's long-window limit of 400 requests / 60s.
+    private static final long SCORESABER_REQUEST_DELAY_MS = 175;
+
     DatabaseManager db;
     ScoreSaber ss;
     JDA jda;
@@ -46,7 +49,6 @@ public class LeaderboardWatcher {
             String updatingMessage = "----- Starting User Refresh... [" + Format.oneDigitZero(LocalTime.now().getHour()) + ":" + Format.oneDigitZero(LocalTime.now().getMinute()) + "]";
             DiscordLogger.sendLogInChannel(updatingMessage, DiscordLogger.WATCHER_REFRESH);
             try {
-                int fetchCounter = 0;
                 List<DataBasePlayer> oldPlayers = db.getAllStoredPlayers();
                 List<DataBasePlayer> updatedPlayers = new ArrayList<>();
                 //Iterate over stored players
@@ -70,15 +72,15 @@ public class LeaderboardWatcher {
                         db.updatePlayer(updatedPlayer);
                     }
 
+                    // ScoreSaber allows ~400 requests / 60s (and 100 / 10s, 25 / 1s). The old 50ms
+                    // delay meant ~20 req/s, roughly 3x over the long-window limit, which is what
+                    // started getting the bot rate limited. Space requests just over the long-window
+                    // budget instead (1 request / 175ms ~= 343 req/min). 429s are additionally retried
+                    // with backoff in HttpMethods, so the periodic one-minute pause is no longer needed.
                     try {
-                        TimeUnit.MILLISECONDS.sleep(50);
+                        TimeUnit.MILLISECONDS.sleep(SCORESABER_REQUEST_DELAY_MS);
                     } catch (InterruptedException e) {
                         e.printStackTrace();
-                    }
-                    fetchCounter++;
-
-                    if (fetchCounter % 200 == 0) {
-                        TimeUnit.MINUTES.sleep(1);
                     }
                 }
 


### PR DESCRIPTION
## Problem

ScoreSaber enforces a **tiered per-IP rate limit** (verified live from the `X-RateLimit-*` response headers):

| Window | Limit | Sustained rate |
|--------|-------|----------------|
| Short  | 25 / 1s   | 25 req/s |
| Medium | 100 / 10s | 10 req/s |
| **Long** | **400 / 60s** | **6.67 req/s** |

The leaderboard refresh sleeps only **50ms** between player fetches (~20 req/s) — roughly **3× over the long-window budget**. So once the bot has tracked enough players it blows past the medium/long windows, ScoreSaber answers `429 Too Many Requests`, and `HttpMethods.get` returns `null` → the player is silently skipped for that refresh. The "pause 1 minute every 200 players" hack doesn't help because the bot is already over budget within the first few seconds.

## Fix

- **`HttpMethods.get`** now retries on HTTP `429` (up to 4 attempts) instead of dropping the player. It waits according to the server's own headers — `Retry-After`, then `X-RateLimit-Reset-Short`, then `X-RateLimit-Reset-Medium` — falling back to exponential backoff (1s, 2s, 4s, 8s) when no header is present.
- **`LeaderboardWatcher`** spaces requests at **175ms** (~343 req/min), just under the long-window limit. The periodic one-minute pause is removed since correct spacing + 429 retries keep the bot within budget.

## Notes

This is independent of the role-flapping fix (#38); they address two different root causes. Verified to compile against the deployed bot's dependencies (`javac`, Java 8). No API/DB/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
