### PR TITLE
Port BeatLeader Clan feature from deployed server build

### DIFF
--- a/src/main/java/bot/api/ApiConstants.java
+++ b/src/main/java/bot/api/ApiConstants.java
@@ -7,6 +7,14 @@ public class ApiConstants {
     //Backend
     public static final String BACKEND_URL = "http://localhost:3001";
     public static final String COMPARISON_URL = BACKEND_URL + "/comparisonImage";
+    public static final String CLAN_PLAYER_URL = "/clan/%s/players";
+    public static final String CLAN_MAPS_URL = "/clan/%s/maps?sortBy=%s&maxPage=%d";
+    public static String getClanPlayerUrl(String clanId) {
+        return String.format(BACKEND_URL + CLAN_PLAYER_URL, clanId);
+    }
+    public static String getClanMapsUrl(String clanId, String sortBy, int maxPage) {
+        return String.format(BACKEND_URL + CLAN_MAPS_URL, clanId, sortBy, maxPage);
+    }
 
     // ScoreSaber
     public static final String SS_PRE_URL = "https://scoresaber.com";
@@ -57,6 +65,26 @@ public class ApiConstants {
     }
     public static String getBeatLeaderPlayerByDiscordId(long discordId) {
         return String.format(BL_PRE_URL + BL_USER_PLAYER_BY_DISCORD_URL, discordId);
+    }
+    public static final String BL_LEADERBOARD_URL = "/leaderboard/%s?leaderboardContext=general&page=1&sortBy=date&order=desc";
+    public static final String BL_LEADERBOARD_CLAN_RANKING_URL = "/leaderboard/clanRankings/%s?page=1";
+    public static final String BL_PLAYER_SCORE_URL = "/score/%s/%s/%s/%s/%s";
+    public static final String BL_ALL_RANKED_SCORES_URL = "/player/%s/accgraph?leaderboardContext=general";
+    public static final String BL_CLAN_TO_HOLD_MAPS_URL = "https://beatleader.xyz/clan/maps/%s/1?sortBy=tohold";
+    public static String getBeatLeaderLeaderboardURL(String leaderboardId) {
+        return String.format(BL_PRE_URL + BL_LEADERBOARD_URL, leaderboardId);
+    }
+    public static String getBeatLeaderLeaderboardClanRankingURL(String leaderboardId) {
+        return String.format(BL_PRE_URL + BL_LEADERBOARD_CLAN_RANKING_URL, leaderboardId);
+    }
+    public static String getBeatLeaderClanToHoldMapsURL(String clanId) {
+        return String.format(BL_CLAN_TO_HOLD_MAPS_URL, clanId);
+    }
+    public static String getBeatLeaderPlayerScoreURL(String leaderboardContext, String playerId, String hash, String diffName, String characteristic) {
+        return String.format(BL_PRE_URL + BL_PLAYER_SCORE_URL, leaderboardContext, playerId, hash, diffName, characteristic);
+    }
+    public static String getBeatLeaderRankedScoresURL(String playerId) {
+        return String.format(BL_PRE_URL + BL_ALL_RANKED_SCORES_URL, playerId);
     }
     public static final String BL_USER_PRE_URL = "https://www.beatleader.xyz/u/";
     public static final String BL_LEADERBOARD_PRE_URL = "https://www.beatleader.xyz/leaderboard/global/";

--- a/src/main/java/bot/api/BeatLeader.java
+++ b/src/main/java/bot/api/BeatLeader.java
@@ -1,9 +1,14 @@
 package bot.api;
 
 import bot.dto.PlayerScore;
+import bot.dto.beatleader.accgraph.PlayerBLRankedScore;
+import bot.dto.beatleader.clanranking.ClanRankingItem;
+import bot.dto.beatleader.clanranking.LeaderboardClanRanking;
 import bot.dto.beatleader.history.PlayerHistoryItem;
 import bot.dto.beatleader.player.BeatLeaderPlayer;
+import bot.dto.beatleader.playerscore.BLPlayerScore;
 import bot.dto.beatleader.scores.PlayerScoreBL;
+import bot.dto.clan.LeaderboardInfo;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -22,6 +27,47 @@ public class BeatLeader {
     public BeatLeader() {
         http = new HttpMethods();
         gson = new Gson();
+    }
+
+    public LeaderboardInfo getLeaderboardInfo(String leaderboardId) {
+        String url = ApiConstants.getBeatLeaderLeaderboardURL(leaderboardId);
+        JsonObject response = http.fetchJsonObject(url);
+        if (response != null) {
+            return gson.fromJson(response.toString(), LeaderboardInfo.class);
+        }
+        return new LeaderboardInfo();
+    }
+
+    public List<ClanRankingItem> getLeaderboardClanRanking(String leaderboardId) {
+        String url = ApiConstants.getBeatLeaderLeaderboardClanRankingURL(leaderboardId);
+        JsonObject response = http.fetchJsonObject(url);
+        if (response != null) {
+            LeaderboardClanRanking ranking = gson.fromJson(response.toString(), LeaderboardClanRanking.class);
+            if (ranking != null) {
+                return ranking.getClanRanking();
+            }
+            return new ArrayList<>();
+        }
+        return new ArrayList<>();
+    }
+
+    public BLPlayerScore getPlayerScore(String leaderboardContext, long playerId, String hash, String diffName, String characteristic) {
+        String url = ApiConstants.getBeatLeaderPlayerScoreURL(leaderboardContext, String.valueOf(playerId), hash, diffName, characteristic);
+        JsonObject response = http.fetchJsonObject(url);
+        if (response != null) {
+            return gson.fromJson(response.toString(), BLPlayerScore.class);
+        }
+        return null;
+    }
+
+    public List<PlayerBLRankedScore> getAllPlayerRankedScores(long playerId) {
+        String url = ApiConstants.getBeatLeaderRankedScoresURL(String.valueOf(playerId));
+        JsonArray response = http.fetchJsonArray(url);
+        if (response != null) {
+            Type listType = new TypeToken<List<PlayerBLRankedScore>>() {}.getType();
+            return gson.fromJson(response.toString(), listType);
+        }
+        return null;
     }
 
     public List<PlayerScore> getTopScoresByPlayerIdAndPage(long playerId, int pageNr) {

--- a/src/main/java/bot/api/NodeBackend.java
+++ b/src/main/java/bot/api/NodeBackend.java
@@ -2,9 +2,16 @@ package bot.api;
 
 import bot.dto.backend.ComparisonPlayerData;
 import bot.dto.backend.ComparisonRequest;
+import bot.dto.clan.ClanMap;
+import bot.dto.clan.ClanPlayer;
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.List;
 
 public class NodeBackend {
     final HttpMethods http;
@@ -22,6 +29,24 @@ public class NodeBackend {
         if (response != null) {
             JsonElement imageElement = response.get("image");
             return imageElement.getAsString();
+        }
+        return null;
+    }
+
+    public List<ClanPlayer> getClanPlayers(String id) {
+        JsonArray response = http.fetchJsonArray(ApiConstants.getClanPlayerUrl(id));
+        if (response != null) {
+            Type listType = new TypeToken<List<ClanPlayer>>() {}.getType();
+            return gson.fromJson(response.toString(), listType);
+        }
+        return null;
+    }
+
+    public List<ClanMap> getClanMaps(String id, String sortBy, int maxPage) {
+        JsonObject response = http.fetchJsonObject(ApiConstants.getClanMapsUrl(id, sortBy, maxPage));
+        if (response != null) {
+            Type listType = new TypeToken<List<ClanMap>>() {}.getType();
+            return gson.fromJson(response.get("maps"), listType);
         }
         return null;
     }

--- a/src/main/java/bot/commands/beatleader/ClanRaid.java
+++ b/src/main/java/bot/commands/beatleader/ClanRaid.java
@@ -1,0 +1,98 @@
+package bot.commands.beatleader;
+
+import bot.api.ApiConstants;
+import bot.api.BeatLeader;
+import bot.api.NodeBackend;
+import bot.commands.beatleader.PlaylistGenerator;
+import bot.dto.MessageEventDTO;
+import bot.dto.beatleader.clanranking.ClanRankingItem;
+import bot.dto.clan.ClanMap;
+import bot.main.BotConstants;
+import bot.utils.Format;
+import bot.utils.Messages;
+import java.awt.image.BufferedImage;
+import java.awt.image.RenderedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.imageio.ImageIO;
+import net.dv8tion.jda.api.entities.MessageChannel;
+
+public class ClanRaid {
+    NodeBackend backend = new NodeBackend();
+    BeatLeader bl = new BeatLeader();
+
+    public void sendClanRaidPlaylist(String clanTag, MessageEventDTO event) {
+        if (clanTag != null && clanTag.equalsIgnoreCase("GER")) {
+            Messages.sendMessage("Haha no.", event);
+            return;
+        }
+        Messages.sendTempMessage("Loading maps. Please wait... \u2728", 14, (MessageChannel)event.getChannel());
+        List<ClanMap> maps = this.backend.getClanMaps(clanTag, "tohold", 10);
+        if (maps.isEmpty()) {
+            Messages.sendMessage("No maps found to conquer.", event);
+            return;
+        }
+        HashMap<String, Double> mapPpDifferences = new HashMap<String, Double>();
+        ArrayList<ClanMap> mapsToRaid = new ArrayList<ClanMap>();
+        String targetClanIcon = null;
+        for (ClanMap mapToRaid : maps) {
+            ClanRankingItem targetClan;
+            String leaderboardId = mapToRaid.getLeaderboardId();
+            List<ClanRankingItem> clanRanking = this.bl.getLeaderboardClanRanking(leaderboardId);
+            ClanRankingItem gerClan = clanRanking.stream().filter(item -> item.getClan().getTag().equalsIgnoreCase("GER")).findFirst().orElse(null);
+            if (gerClan == null || (targetClan = (ClanRankingItem)clanRanking.stream().filter(item -> item.getClan().getTag().equalsIgnoreCase(clanTag)).findFirst().orElse(null)) == null) continue;
+            if (targetClanIcon == null) {
+                targetClanIcon = targetClan.getClan().getIcon();
+            }
+            double ppDifference = Math.abs(gerClan.getPp() - targetClan.getPp());
+            mapPpDifferences.put(mapToRaid.getSongName(), ppDifference);
+            mapsToRaid.add(mapToRaid);
+        }
+        mapsToRaid.sort(Comparator.comparingDouble(m -> (Double)mapPpDifferences.get(m.getSongName())));
+        List ppDifferencesList = mapPpDifferences.entrySet().stream().sorted(Map.Entry.comparingByValue()).map(entry -> String.format("%-40s: %.3f PP", entry.getKey(), entry.getValue())).collect(Collectors.toList());
+        Object ppDifferencesMessage = String.join((CharSequence)"\n", ppDifferencesList.subList(0, Math.min(25, ppDifferencesList.size())));
+        if (ppDifferencesList.size() > 25) {
+            ppDifferencesMessage = (String)ppDifferencesMessage + "\n...and " + (ppDifferencesList.size() - 25) + " more";
+        }
+        ppDifferencesMessage = Format.codeAutohotkey((String)ppDifferencesMessage);
+        String titleUrl = ApiConstants.getBeatLeaderClanToHoldMapsURL(clanTag);
+        Messages.sendMessageWithTitle((String)ppDifferencesMessage, Format.underline("PP Differences between " + Format.bold("GER") + " and " + Format.bold(clanTag)), titleUrl, event);
+        String title = clanTag + " Clan Raid Maps";
+        String clanRaidIcon = this.getBase64ImageFromUrl(targetClanIcon);
+        if (clanRaidIcon == null) {
+            clanRaidIcon = this.getBase64ImageFromUrl("https://i.imgur.com/2V038wD.png");
+        }
+        String fileName = "BSG_Raid_Maps_" + clanTag + ".json";
+        String filePath = BotConstants.RESOURCES_PATH + fileName;
+        PlaylistGenerator.generatePlaylistFile(mapsToRaid, title, clanRaidIcon, filePath, "bsgraid" + clanTag + System.currentTimeMillis(), null);
+        File file = new File(filePath);
+        Messages.sendFile(file, fileName, (MessageChannel)event.getChannel());
+    }
+
+    public String getBase64ImageFromUrl(String urlString) {
+        if (urlString == null) {
+            return null;
+        }
+        try {
+            URL url = new URL(urlString);
+            BufferedImage image = ImageIO.read(url);
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            ImageIO.write((RenderedImage)image, "png", byteArrayOutputStream);
+            byte[] imageBytes = byteArrayOutputStream.toByteArray();
+            return "base64," + Base64.getEncoder().encodeToString(imageBytes);
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}
+

--- a/src/main/java/bot/commands/beatleader/ClanRaid.java
+++ b/src/main/java/bot/commands/beatleader/ClanRaid.java
@@ -36,6 +36,10 @@ public class ClanRaid {
         }
         Messages.sendTempMessage("Loading maps. Please wait... \u2728", 14, (MessageChannel)event.getChannel());
         List<ClanMap> maps = this.backend.getClanMaps(clanTag, "tohold", 10);
+        if (maps == null) {
+            Messages.sendMessage("Could not fetch clan maps. Please try again later.", event);
+            return;
+        }
         if (maps.isEmpty()) {
             Messages.sendMessage("No maps found to conquer.", event);
             return;

--- a/src/main/java/bot/commands/beatleader/ClanStats.java
+++ b/src/main/java/bot/commands/beatleader/ClanStats.java
@@ -1,0 +1,56 @@
+package bot.commands.beatleader;
+
+import bot.db.DatabaseManager;
+import bot.dto.MessageEventDTO;
+import bot.dto.player.DataBasePlayer;
+import bot.utils.Messages;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ClanStats {
+    private final DatabaseManager dbManager;
+    private static final String BL_PROFILE_URL = "https://www.beatleader.xyz/u/";
+    private static final String CLAN_URL = "https://beatleader.xyz/clan/GER";
+
+    public ClanStats(DatabaseManager dbManager) {
+        this.dbManager = dbManager;
+    }
+
+    public void executeClanStatsCommand(MessageEventDTO event) {
+        Map<Long, Integer> captureCounts = this.dbManager.getCaptureCounts();
+        List sortedEntries = captureCounts.entrySet().stream().sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())).collect(Collectors.toList());
+        StringBuilder leaderboard = new StringBuilder();
+        for (int i = 0; i < Math.min(25, sortedEntries.size()); ++i) {
+            Map.Entry entry = (Map.Entry)sortedEntries.get(i);
+            String playerLine = this.formatPlayerRank((Long)entry.getKey(), i + 1, (Integer)entry.getValue());
+            leaderboard.append(playerLine).append("\n");
+        }
+        Messages.sendMessageWithTitle(leaderboard.toString(), "\ud83d\udc51 Clan Capture Leaderboard \ud83d\udc51", CLAN_URL, event);
+    }
+
+    private String formatPlayerRank(Long playerId, int rank, int captureCount) {
+        DataBasePlayer player = this.dbManager.getPlayerById(playerId);
+        String playerName = player != null ? player.getName() : "Unregistered Player";
+        String playerProfileLink = BL_PROFILE_URL + playerId;
+        String medalEmoji = this.getMedalEmoji(rank);
+        return medalEmoji + " **" + String.format("[%s](%s)** - Captures: **%d**", playerName, playerProfileLink, captureCount);
+    }
+
+    private String getMedalEmoji(int rank) {
+        switch (rank) {
+            case 1: {
+                return ":first_place_medal: ";
+            }
+            case 2: {
+                return ":second_place_medal: ";
+            }
+            case 3: {
+                return ":third_place_medal: ";
+            }
+        }
+        return "#" + rank + " ";
+    }
+}
+

--- a/src/main/java/bot/commands/beatleader/PlaylistGenerator.java
+++ b/src/main/java/bot/commands/beatleader/PlaylistGenerator.java
@@ -1,0 +1,51 @@
+package bot.commands.beatleader;
+
+import bot.dto.clan.ClanMap;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PlaylistGenerator {
+    public static void generatePlaylistFile(List<ClanMap> maps, String title, String clanIcon, String filePath, String id, String syncUrl) {
+        JSONObject playlist = new JSONObject();
+        playlist.put("playlistTitle", (Object)title);
+        playlist.put("playlistAuthor", (Object)"Beat Saber Germany");
+        playlist.put("playlistDescription", (Object)"Maps to help the GER Clan rise!");
+        playlist.put("image", (Object)clanIcon);
+        JSONObject customData = new JSONObject();
+        if (syncUrl != null) {
+            customData.put("syncURL", (Object)syncUrl);
+        }
+        customData.put("owner", (Object)"Beat Saber Germany");
+        customData.put("id", (Object)id);
+        customData.put("hash", JSONObject.NULL);
+        customData.put("shared", false);
+        playlist.put("customData", (Object)customData);
+        JSONArray songArray = new JSONArray();
+        for (ClanMap map : maps) {
+            JSONObject song = new JSONObject();
+            song.put("songName", (Object)map.getSongName());
+            song.put("levelAuthorName", (Object)map.getSongMapper());
+            song.put("hash", (Object)map.getSongHash().toUpperCase());
+            song.put("levelid", (Object)("custom_level_" + map.getSongHash().toUpperCase()));
+            song.put("coverURL", (Object)map.getSongCover());
+            JSONArray difficultiesArray = new JSONArray();
+            JSONObject difficulty = new JSONObject();
+            difficulty.put("characteristic", (Object)"Standard");
+            difficulty.put("name", (Object)map.getDifficultyName().toLowerCase());
+            difficultiesArray.put((Object)difficulty);
+            song.put("difficulties", (Object)difficultiesArray);
+            songArray.put((Object)song);
+        }
+        playlist.put("songs", (Object)songArray);
+        try (FileWriter file = new FileWriter(filePath);){
+            file.write(playlist.toString(4));
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}
+

--- a/src/main/java/bot/commands/beatleader/ToConquer.java
+++ b/src/main/java/bot/commands/beatleader/ToConquer.java
@@ -25,13 +25,19 @@ public class ToConquer {
         Messages.sendTempMessage(tempMessage, tempMessageDuration, (MessageChannel)event.getChannel());
         int maxPage = filter != null ? 20 : 10;
         List<ClanMap> maps = this.backend.getClanMaps("GER", "toconquer", maxPage);
+        if (maps == null) {
+            Messages.sendMessage("Could not fetch clan maps. Please try again later.", event);
+            return;
+        }
         StringBuilder titleDetails = new StringBuilder();
         StringBuilder filenameDetails = new StringBuilder();
         if (filter != null) {
             maps.removeIf(map -> map.getAccRating() > filter.getMaxAccRating() || map.getPassRating() > filter.getMaxPassRating() || map.getTechRating() > filter.getMaxTechRating());
             if (filter.isUnplayedOnly()) {
                 List<PlayerBLRankedScore> playerRankedScores = this.bl.getAllPlayerRankedScores(player.getPlayerIdLong());
-                maps.removeIf(map -> playerRankedScores.stream().anyMatch(s -> s.getLeaderboardId().equals(map.getLeaderboardId())));
+                if (playerRankedScores != null) {
+                    maps.removeIf(map -> playerRankedScores.stream().anyMatch(s -> s.getLeaderboardId().equals(map.getLeaderboardId())));
+                }
             }
             if (filter.getMaxAccRating() != 9999999.0f) {
                 titleDetails.append(" Acc \u2264 ").append(filter.getMaxAccRating()).append(",");

--- a/src/main/java/bot/commands/beatleader/ToConquer.java
+++ b/src/main/java/bot/commands/beatleader/ToConquer.java
@@ -1,0 +1,76 @@
+package bot.commands.beatleader;
+
+import bot.api.BeatLeader;
+import bot.api.NodeBackend;
+import bot.commands.beatleader.PlaylistGenerator;
+import bot.dto.MessageEventDTO;
+import bot.dto.beatleader.ClanPlaylistFilter;
+import bot.dto.beatleader.accgraph.PlayerBLRankedScore;
+import bot.dto.clan.ClanMap;
+import bot.dto.player.DataBasePlayer;
+import bot.main.BotConstants;
+import bot.utils.Format;
+import bot.utils.Messages;
+import java.io.File;
+import java.util.List;
+import net.dv8tion.jda.api.entities.MessageChannel;
+
+public class ToConquer {
+    NodeBackend backend = new NodeBackend();
+    BeatLeader bl = new BeatLeader();
+
+    public void sendToConquerPlaylist(int limit, ClanPlaylistFilter filter, DataBasePlayer player, MessageEventDTO event) {
+        String tempMessage = filter == null ? "Fetching maps. Please wait..." : "Building playlist based on your filter, this may take some time...";
+        int tempMessageDuration = filter == null ? 15 : 20;
+        Messages.sendTempMessage(tempMessage, tempMessageDuration, (MessageChannel)event.getChannel());
+        int maxPage = filter != null ? 20 : 10;
+        List<ClanMap> maps = this.backend.getClanMaps("GER", "toconquer", maxPage);
+        StringBuilder titleDetails = new StringBuilder();
+        StringBuilder filenameDetails = new StringBuilder();
+        if (filter != null) {
+            maps.removeIf(map -> map.getAccRating() > filter.getMaxAccRating() || map.getPassRating() > filter.getMaxPassRating() || map.getTechRating() > filter.getMaxTechRating());
+            if (filter.isUnplayedOnly()) {
+                List<PlayerBLRankedScore> playerRankedScores = this.bl.getAllPlayerRankedScores(player.getPlayerIdLong());
+                maps.removeIf(map -> playerRankedScores.stream().anyMatch(s -> s.getLeaderboardId().equals(map.getLeaderboardId())));
+            }
+            if (filter.getMaxAccRating() != 9999999.0f) {
+                titleDetails.append(" Acc \u2264 ").append(filter.getMaxAccRating()).append(",");
+                filenameDetails.append("_Acc").append(filter.getMaxAccRating());
+            }
+            if (filter.getMaxPassRating() != 9999999.0f) {
+                titleDetails.append(" Pass \u2264 ").append(filter.getMaxPassRating()).append(",");
+                filenameDetails.append("_Pass").append(filter.getMaxPassRating());
+            }
+            if (filter.getMaxTechRating() != 9999999.0f) {
+                titleDetails.append(" Tech \u2264 ").append(filter.getMaxTechRating()).append(",");
+                filenameDetails.append("_Tech").append(filter.getMaxTechRating());
+            }
+            if (filter.isUnplayedOnly()) {
+                titleDetails.append(" Unplayed");
+                filenameDetails.append("_Unplayed");
+            }
+        }
+        if (maps.isEmpty()) {
+            Messages.sendMessage("No maps found to conquer that match the filter criteria.", event);
+            return;
+        }
+        if (maps.size() > limit) {
+            maps = maps.subList(0, limit);
+        }
+        String baseTitle = filter == null ? "GER maps to conquer" : "ToConquer";
+        String title = baseTitle + titleDetails;
+        String clanIcon = filter == null ? BotConstants.playlistImageBsg : BotConstants.filterPlaylistImageBsg;
+        String baseFilePath = BotConstants.RESOURCES_PATH + "BSG_Conquer_Maps";
+        String filePath = baseFilePath + filenameDetails + ".json";
+        String syncUrl = filter == null ? "https://anti.link/playlists/BSG_Conquer_Maps.json" : null;
+        PlaylistGenerator.generatePlaylistFile(maps, title, clanIcon, filePath, "bsgconquer", syncUrl);
+        if (filter != null) {
+            String mapCount = Format.bold(String.valueOf(maps.size()));
+            String message = "Found " + mapCount + " maps matching your filter:" + Format.bold(titleDetails.toString());
+            Messages.sendPlainMessage(message, event.getChannel());
+        }
+        File file = new File(filePath);
+        Messages.sendFile(file, title + ".json", (MessageChannel)event.getChannel());
+    }
+}
+

--- a/src/main/java/bot/db/DatabaseManager.java
+++ b/src/main/java/bot/db/DatabaseManager.java
@@ -18,13 +18,16 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class DatabaseManager {
     private MongoClient mongoClient;
     private MongoDatabase database;
     private MongoCollection<Document> playersCollection;
     private MongoCollection<Document> supportersCollection;
+    private MongoCollection<Document> captureCountsCollection;
 
     public void connectToDatabase() {
         try {
@@ -35,6 +38,7 @@ public class DatabaseManager {
                 database = mongoClient.getDatabase(DBConstants.DB_DATABASE);
                 playersCollection = database.getCollection("players");
                 supportersCollection = database.getCollection("supporters");
+                captureCountsCollection = database.getCollection("clancapturecounts");
                 System.out.println("*** Connected to database: MongoDB");
             }
         } catch (Exception e) {
@@ -104,6 +108,38 @@ public class DatabaseManager {
         }
         Document document = database.getCollection("players").find(Filters.eq("player_name", playerName)).first();
         return document != null ? DataBasePlayer.fromDocument(document) : null;
+    }
+
+    public DataBasePlayer getPlayerById(long playerId) {
+        Document document = playersCollection.find(Filters.eq("player_id", playerId)).first();
+        return document != null ? DataBasePlayer.fromDocument(document) : null;
+    }
+
+    public void incrementCaptureCount(long playerId) {
+        Document document = captureCountsCollection.find(Filters.eq("player_id", playerId)).first();
+        if (document != null) {
+            int count = document.getInteger("count");
+            captureCountsCollection.updateOne(Filters.eq("player_id", playerId), new Document("$set", new Document("count", count + 1)));
+        } else {
+            document = new Document("player_id", playerId).append("count", 1);
+            captureCountsCollection.insertOne(document);
+        }
+    }
+
+    public Map<Long, Integer> getCaptureCounts() {
+        Map<Long, Integer> counts = new HashMap<>();
+        FindIterable<Document> documents = captureCountsCollection.find();
+        for (Document doc : documents) {
+            Number playerId = doc.get("player_id", Number.class);
+            Integer count = doc.getInteger("count", 0);
+            counts.put(playerId.longValue(), count);
+        }
+        return counts;
+    }
+
+    public int getCaptureCount(long playerId) {
+        Document document = captureCountsCollection.find(Filters.eq("player_id", playerId)).first();
+        return document != null ? document.getInteger("count", 0) : 0;
     }
 
     public DataBasePlayer getPlayerByDiscordId(long discordUserId) {

--- a/src/main/java/bot/dto/beatleader/ClanPlaylistFilter.java
+++ b/src/main/java/bot/dto/beatleader/ClanPlaylistFilter.java
@@ -1,0 +1,48 @@
+package bot.dto.beatleader;
+
+public class ClanPlaylistFilter {
+    public float maxAccRating;
+    public float maxPassRating;
+    public float maxTechRating;
+    public boolean unplayedOnly;
+
+    public ClanPlaylistFilter(float maxAccRating, float maxPassRating, float maxTechRating, boolean unplayedOnly) {
+        this.maxAccRating = maxAccRating;
+        this.maxPassRating = maxPassRating;
+        this.maxTechRating = maxTechRating;
+        this.unplayedOnly = unplayedOnly;
+    }
+
+    public float getMaxAccRating() {
+        return this.maxAccRating;
+    }
+
+    public void setMaxAccRating(float maxAccRating) {
+        this.maxAccRating = maxAccRating;
+    }
+
+    public float getMaxPassRating() {
+        return this.maxPassRating;
+    }
+
+    public void setMaxPassRating(float maxPassRating) {
+        this.maxPassRating = maxPassRating;
+    }
+
+    public float getMaxTechRating() {
+        return this.maxTechRating;
+    }
+
+    public void setMaxTechRating(float maxTechRating) {
+        this.maxTechRating = maxTechRating;
+    }
+
+    public boolean isUnplayedOnly() {
+        return this.unplayedOnly;
+    }
+
+    public void setUnplayedOnly(boolean unplayedOnly) {
+        this.unplayedOnly = unplayedOnly;
+    }
+}
+

--- a/src/main/java/bot/dto/beatleader/accgraph/PlayerBLRankedScore.java
+++ b/src/main/java/bot/dto/beatleader/accgraph/PlayerBLRankedScore.java
@@ -1,0 +1,85 @@
+package bot.dto.beatleader.accgraph;
+
+import com.google.gson.annotations.SerializedName;
+
+public class PlayerBLRankedScore {
+    @SerializedName(value="acc")
+    private double acc;
+    @SerializedName(value="songName")
+    private String songName;
+    @SerializedName(value="diff")
+    private String diff;
+    @SerializedName(value="mapper")
+    private String mapper;
+    @SerializedName(value="leaderboardId")
+    private String leaderboardId;
+    @SerializedName(value="stars")
+    private double stars;
+    @SerializedName(value="modifiers")
+    private String modifiers;
+    @SerializedName(value="techRating")
+    private double techRating;
+    @SerializedName(value="mode")
+    private String mode;
+    @SerializedName(value="passRating")
+    private double passRating;
+    @SerializedName(value="timeset")
+    private int timeset;
+    @SerializedName(value="accRating")
+    private double accRating;
+    @SerializedName(value="hash")
+    private String hash;
+
+    public double getAcc() {
+        return this.acc;
+    }
+
+    public String getSongName() {
+        return this.songName;
+    }
+
+    public String getDiff() {
+        return this.diff;
+    }
+
+    public String getMapper() {
+        return this.mapper;
+    }
+
+    public String getLeaderboardId() {
+        return this.leaderboardId;
+    }
+
+    public double getStars() {
+        return this.stars;
+    }
+
+    public String getModifiers() {
+        return this.modifiers;
+    }
+
+    public Object getTechRating() {
+        return this.techRating;
+    }
+
+    public String getMode() {
+        return this.mode;
+    }
+
+    public double getPassRating() {
+        return this.passRating;
+    }
+
+    public int getTimeset() {
+        return this.timeset;
+    }
+
+    public double getAccRating() {
+        return this.accRating;
+    }
+
+    public String getHash() {
+        return this.hash;
+    }
+}
+

--- a/src/main/java/bot/dto/beatleader/clanranking/ClanRankingItem.java
+++ b/src/main/java/bot/dto/beatleader/clanranking/ClanRankingItem.java
@@ -56,7 +56,7 @@ public class ClanRankingItem {
         this.averageAccuracy = averageAccuracy;
     }
 
-    public class Clan {
+    public static class Clan {
         private int id;
         private String name;
         private String color;

--- a/src/main/java/bot/dto/beatleader/clanranking/ClanRankingItem.java
+++ b/src/main/java/bot/dto/beatleader/clanranking/ClanRankingItem.java
@@ -1,0 +1,143 @@
+package bot.dto.beatleader.clanranking;
+
+public class ClanRankingItem {
+    private int id;
+    private Clan clan;
+    private int rank;
+    private double pp;
+    private double averageRank;
+    private double averageAccuracy;
+
+    public int getId() {
+        return this.id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public Clan getClan() {
+        return this.clan;
+    }
+
+    public void setClan(Clan clan) {
+        this.clan = clan;
+    }
+
+    public int getRank() {
+        return this.rank;
+    }
+
+    public void setRank(int rank) {
+        this.rank = rank;
+    }
+
+    public double getPp() {
+        return this.pp;
+    }
+
+    public void setPp(double pp) {
+        this.pp = pp;
+    }
+
+    public double getAverageRank() {
+        return this.averageRank;
+    }
+
+    public void setAverageRank(double averageRank) {
+        this.averageRank = averageRank;
+    }
+
+    public double getAverageAccuracy() {
+        return this.averageAccuracy;
+    }
+
+    public void setAverageAccuracy(double averageAccuracy) {
+        this.averageAccuracy = averageAccuracy;
+    }
+
+    public class Clan {
+        private int id;
+        private String name;
+        private String color;
+        private String icon;
+        private String tag;
+        private String leaderID;
+        private String description;
+        private String bio;
+        private int playersCount;
+
+        public int getId() {
+            return this.id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getColor() {
+            return this.color;
+        }
+
+        public void setColor(String color) {
+            this.color = color;
+        }
+
+        public String getIcon() {
+            return this.icon;
+        }
+
+        public void setIcon(String icon) {
+            this.icon = icon;
+        }
+
+        public String getTag() {
+            return this.tag;
+        }
+
+        public void setTag(String tag) {
+            this.tag = tag;
+        }
+
+        public String getLeaderID() {
+            return this.leaderID;
+        }
+
+        public void setLeaderID(String leaderID) {
+            this.leaderID = leaderID;
+        }
+
+        public String getDescription() {
+            return this.description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public String getBio() {
+            return this.bio;
+        }
+
+        public void setBio(String bio) {
+            this.bio = bio;
+        }
+
+        public int getPlayersCount() {
+            return this.playersCount;
+        }
+
+        public void setPlayersCount(int playersCount) {
+            this.playersCount = playersCount;
+        }
+    }
+}
+

--- a/src/main/java/bot/dto/beatleader/clanranking/LeaderboardClanRanking.java
+++ b/src/main/java/bot/dto/beatleader/clanranking/LeaderboardClanRanking.java
@@ -1,0 +1,17 @@
+package bot.dto.beatleader.clanranking;
+
+import bot.dto.beatleader.clanranking.ClanRankingItem;
+import java.util.List;
+
+public class LeaderboardClanRanking {
+    private List<ClanRankingItem> clanRanking;
+
+    public List<ClanRankingItem> getClanRanking() {
+        return this.clanRanking;
+    }
+
+    public void setClanRanking(List<ClanRankingItem> clanRanking) {
+        this.clanRanking = clanRanking;
+    }
+}
+

--- a/src/main/java/bot/dto/beatleader/playerscore/BLPlayerScore.java
+++ b/src/main/java/bot/dto/beatleader/playerscore/BLPlayerScore.java
@@ -1,0 +1,41 @@
+package bot.dto.beatleader.playerscore;
+
+import bot.dto.beatleader.playerscore.Difficulty;
+import bot.dto.beatleader.playerscore.Performance;
+import bot.dto.beatleader.playerscore.Player;
+import bot.dto.beatleader.playerscore.Song;
+import com.google.gson.annotations.SerializedName;
+
+public class BLPlayerScore {
+    @SerializedName(value="difficulty")
+    private Difficulty difficulty;
+    @SerializedName(value="song")
+    private Song song;
+    @SerializedName(value="performance")
+    private Performance performance;
+    @SerializedName(value="replay")
+    private String replay;
+    @SerializedName(value="player")
+    private Player player;
+
+    public Difficulty getDifficulty() {
+        return this.difficulty;
+    }
+
+    public Song getSong() {
+        return this.song;
+    }
+
+    public Performance getPerformance() {
+        return this.performance;
+    }
+
+    public String getReplay() {
+        return this.replay;
+    }
+
+    public Player getPlayer() {
+        return this.player;
+    }
+}
+

--- a/src/main/java/bot/dto/beatleader/playerscore/Difficulty.java
+++ b/src/main/java/bot/dto/beatleader/playerscore/Difficulty.java
@@ -1,0 +1,37 @@
+package bot.dto.beatleader.playerscore;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Difficulty {
+    @SerializedName(value="modeName")
+    private String modeName;
+    @SerializedName(value="id")
+    private int id;
+    @SerializedName(value="stars")
+    private float stars;
+    @SerializedName(value="value")
+    private int value;
+    @SerializedName(value="difficultyName")
+    private String difficultyName;
+
+    public String getModeName() {
+        return this.modeName;
+    }
+
+    public int getId() {
+        return this.id;
+    }
+
+    public float getStars() {
+        return this.stars;
+    }
+
+    public int getValue() {
+        return this.value;
+    }
+
+    public String getDifficultyName() {
+        return this.difficultyName;
+    }
+}
+

--- a/src/main/java/bot/dto/beatleader/playerscore/Performance.java
+++ b/src/main/java/bot/dto/beatleader/playerscore/Performance.java
@@ -1,0 +1,67 @@
+package bot.dto.beatleader.playerscore;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Performance {
+    @SerializedName(value="pp")
+    private float pp;
+    @SerializedName(value="fullCombo")
+    private boolean fullCombo;
+    @SerializedName(value="pauses")
+    private int pauses;
+    @SerializedName(value="modifiedScore")
+    private int modifiedScore;
+    @SerializedName(value="accuracy")
+    private Object accuracy;
+    @SerializedName(value="rank")
+    private int rank;
+    @SerializedName(value="baseScore")
+    private int baseScore;
+    @SerializedName(value="missedNotes")
+    private int missedNotes;
+    @SerializedName(value="maxCombo")
+    private int maxCombo;
+    @SerializedName(value="badCuts")
+    private int badCuts;
+
+    public float getPp() {
+        return this.pp;
+    }
+
+    public boolean isFullCombo() {
+        return this.fullCombo;
+    }
+
+    public int getPauses() {
+        return this.pauses;
+    }
+
+    public int getModifiedScore() {
+        return this.modifiedScore;
+    }
+
+    public Object getAccuracy() {
+        return this.accuracy;
+    }
+
+    public int getRank() {
+        return this.rank;
+    }
+
+    public int getBaseScore() {
+        return this.baseScore;
+    }
+
+    public int getMissedNotes() {
+        return this.missedNotes;
+    }
+
+    public int getMaxCombo() {
+        return this.maxCombo;
+    }
+
+    public int getBadCuts() {
+        return this.badCuts;
+    }
+}
+

--- a/src/main/java/bot/dto/beatleader/playerscore/Player.java
+++ b/src/main/java/bot/dto/beatleader/playerscore/Player.java
@@ -1,0 +1,31 @@
+package bot.dto.beatleader.playerscore;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Player {
+    @SerializedName(value="country")
+    private String country;
+    @SerializedName(value="name")
+    private String name;
+    @SerializedName(value="rank")
+    private int rank;
+    @SerializedName(value="id")
+    private String id;
+
+    public String getCountry() {
+        return this.country;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public int getRank() {
+        return this.rank;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+}
+

--- a/src/main/java/bot/dto/beatleader/playerscore/Song.java
+++ b/src/main/java/bot/dto/beatleader/playerscore/Song.java
@@ -1,0 +1,37 @@
+package bot.dto.beatleader.playerscore;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Song {
+    @SerializedName(value="cover")
+    private String cover;
+    @SerializedName(value="author")
+    private String author;
+    @SerializedName(value="name")
+    private String name;
+    @SerializedName(value="mapper")
+    private String mapper;
+    @SerializedName(value="id")
+    private String id;
+
+    public String getCover() {
+        return this.cover;
+    }
+
+    public String getAuthor() {
+        return this.author;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getMapper() {
+        return this.mapper;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+}
+

--- a/src/main/java/bot/dto/clan/ClanMap.java
+++ b/src/main/java/bot/dto/clan/ClanMap.java
@@ -1,0 +1,211 @@
+package bot.dto.clan;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ClanMap {
+    @SerializedName(value="rank")
+    private int rank;
+    @SerializedName(value="ppDiff")
+    private double ppDiff;
+    @SerializedName(value="lastUpdateTime")
+    private long lastUpdateTime;
+    @SerializedName(value="averageAccuracy")
+    private double averageAccuracy;
+    @SerializedName(value="leaderboardId")
+    private String leaderboardId;
+    @SerializedName(value="songId")
+    private String songId;
+    @SerializedName(value="songHash")
+    private String songHash;
+    @SerializedName(value="songName")
+    private String songName;
+    @SerializedName(value="songMapper")
+    private String songMapper;
+    @SerializedName(value="songCover")
+    private String songCover;
+    @SerializedName(value="songBpm")
+    private float songBpm;
+    @SerializedName(value="songDuration")
+    private int songDuration;
+    @SerializedName(value="difficultyName")
+    private String difficultyName;
+    @SerializedName(value="plays")
+    private int plays;
+    @SerializedName(value="playCount")
+    private int playCount;
+    @SerializedName(value="positiveVotes")
+    private int positiveVotes;
+    @SerializedName(value="negativeVotes")
+    private int negativeVotes;
+    @SerializedName(value="accRating")
+    private float accRating;
+    @SerializedName(value="passRating")
+    private float passRating;
+    @SerializedName(value="techRating")
+    private float techRating;
+
+    public int getRank() {
+        return this.rank;
+    }
+
+    public void setRank(int rank) {
+        this.rank = rank;
+    }
+
+    public double getPpDiff() {
+        return this.ppDiff;
+    }
+
+    public void setPpDiff(double ppDiff) {
+        this.ppDiff = ppDiff;
+    }
+
+    public long getLastUpdateTime() {
+        return this.lastUpdateTime;
+    }
+
+    public void setLastUpdateTime(long lastUpdateTime) {
+        this.lastUpdateTime = lastUpdateTime;
+    }
+
+    public double getAverageAccuracy() {
+        return this.averageAccuracy;
+    }
+
+    public void setAverageAccuracy(double averageAccuracy) {
+        this.averageAccuracy = averageAccuracy;
+    }
+
+    public String getLeaderboardId() {
+        return this.leaderboardId;
+    }
+
+    public void setLeaderboardId(String leaderboardId) {
+        this.leaderboardId = leaderboardId;
+    }
+
+    public String getSongId() {
+        return this.songId;
+    }
+
+    public void setSongId(String songId) {
+        this.songId = songId;
+    }
+
+    public String getSongName() {
+        return this.songName;
+    }
+
+    public void setSongName(String songName) {
+        this.songName = songName;
+    }
+
+    public String getSongMapper() {
+        return this.songMapper;
+    }
+
+    public void setSongMapper(String songMapper) {
+        this.songMapper = songMapper;
+    }
+
+    public String getSongCover() {
+        return this.songCover;
+    }
+
+    public void setSongCover(String songCover) {
+        this.songCover = songCover;
+    }
+
+    public float getSongBpm() {
+        return this.songBpm;
+    }
+
+    public void setSongBpm(int songBpm) {
+        this.songBpm = songBpm;
+    }
+
+    public int getSongDuration() {
+        return this.songDuration;
+    }
+
+    public void setSongDuration(int songDuration) {
+        this.songDuration = songDuration;
+    }
+
+    public String getDifficultyName() {
+        return this.difficultyName;
+    }
+
+    public void setDifficultyName(String difficultyName) {
+        this.difficultyName = difficultyName;
+    }
+
+    public int getPlays() {
+        return this.plays;
+    }
+
+    public void setPlays(int plays) {
+        this.plays = plays;
+    }
+
+    public int getPlayCount() {
+        return this.playCount;
+    }
+
+    public void setPlayCount(int playCount) {
+        this.playCount = playCount;
+    }
+
+    public int getPositiveVotes() {
+        return this.positiveVotes;
+    }
+
+    public void setPositiveVotes(int positiveVotes) {
+        this.positiveVotes = positiveVotes;
+    }
+
+    public int getNegativeVotes() {
+        return this.negativeVotes;
+    }
+
+    public void setNegativeVotes(int negativeVotes) {
+        this.negativeVotes = negativeVotes;
+    }
+
+    public String getSongHash() {
+        return this.songHash;
+    }
+
+    public void setSongHash(String songHash) {
+        this.songHash = songHash;
+    }
+
+    public void setSongBpm(float songBpm) {
+        this.songBpm = songBpm;
+    }
+
+    public float getAccRating() {
+        return this.accRating;
+    }
+
+    public void setAccRating(float accRating) {
+        this.accRating = accRating;
+    }
+
+    public float getPassRating() {
+        return this.passRating;
+    }
+
+    public void setPassRating(float passRating) {
+        this.passRating = passRating;
+    }
+
+    public float getTechRating() {
+        return this.techRating;
+    }
+
+    public void setTechRating(float techRating) {
+        this.techRating = techRating;
+    }
+}
+

--- a/src/main/java/bot/dto/clan/ClanPlayer.java
+++ b/src/main/java/bot/dto/clan/ClanPlayer.java
@@ -1,0 +1,168 @@
+package bot.dto.clan;
+
+import bot.dto.clan.ProfileSettings;
+import com.google.gson.annotations.SerializedName;
+
+public class ClanPlayer {
+    @SerializedName(value="pp")
+    private double pp;
+    @SerializedName(value="country")
+    private String country;
+    @SerializedName(value="role")
+    private String role;
+    @SerializedName(value="contextExtensions")
+    private Object contextExtensions;
+    @SerializedName(value="bot")
+    private boolean bot;
+    @SerializedName(value="avatar")
+    private String avatar;
+    @SerializedName(value="clanOrder")
+    private String clanOrder;
+    @SerializedName(value="platform")
+    private String platform;
+    @SerializedName(value="profileSettings")
+    private ProfileSettings profileSettings;
+    @SerializedName(value="patreonFeatures")
+    private Object patreonFeatures;
+    @SerializedName(value="name")
+    private String name;
+    @SerializedName(value="clans")
+    private Object clans;
+    @SerializedName(value="rank")
+    private int rank;
+    @SerializedName(value="id")
+    private String id;
+    @SerializedName(value="socials")
+    private Object socials;
+    @SerializedName(value="countryRank")
+    private int countryRank;
+
+    public void setPp(double pp) {
+        this.pp = pp;
+    }
+
+    public double getPp() {
+        return this.pp;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getCountry() {
+        return this.country;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getRole() {
+        return this.role;
+    }
+
+    public void setContextExtensions(Object contextExtensions) {
+        this.contextExtensions = contextExtensions;
+    }
+
+    public Object getContextExtensions() {
+        return this.contextExtensions;
+    }
+
+    public void setBot(boolean bot) {
+        this.bot = bot;
+    }
+
+    public boolean isBot() {
+        return this.bot;
+    }
+
+    public void setAvatar(String avatar) {
+        this.avatar = avatar;
+    }
+
+    public String getAvatar() {
+        return this.avatar;
+    }
+
+    public void setClanOrder(String clanOrder) {
+        this.clanOrder = clanOrder;
+    }
+
+    public String getClanOrder() {
+        return this.clanOrder;
+    }
+
+    public void setPlatform(String platform) {
+        this.platform = platform;
+    }
+
+    public String getPlatform() {
+        return this.platform;
+    }
+
+    public void setProfileSettings(ProfileSettings profileSettings) {
+        this.profileSettings = profileSettings;
+    }
+
+    public ProfileSettings getProfileSettings() {
+        return this.profileSettings;
+    }
+
+    public void setPatreonFeatures(Object patreonFeatures) {
+        this.patreonFeatures = patreonFeatures;
+    }
+
+    public Object getPatreonFeatures() {
+        return this.patreonFeatures;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setClans(Object clans) {
+        this.clans = clans;
+    }
+
+    public Object getClans() {
+        return this.clans;
+    }
+
+    public void setRank(int rank) {
+        this.rank = rank;
+    }
+
+    public int getRank() {
+        return this.rank;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public void setSocials(Object socials) {
+        this.socials = socials;
+    }
+
+    public Object getSocials() {
+        return this.socials;
+    }
+
+    public void setCountryRank(int countryRank) {
+        this.countryRank = countryRank;
+    }
+
+    public int getCountryRank() {
+        return this.countryRank;
+    }
+}
+

--- a/src/main/java/bot/dto/clan/LeaderboardInfo.java
+++ b/src/main/java/bot/dto/clan/LeaderboardInfo.java
@@ -1,0 +1,230 @@
+package bot.dto.clan;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.List;
+
+public class LeaderboardInfo {
+    @SerializedName(value="id")
+    private String leaderboardId;
+    @SerializedName(value="song")
+    private SongInfo song;
+    @SerializedName(value="clan")
+    private ClanInfo clan;
+    @SerializedName(value="scores")
+    private List<Score> scores;
+
+    public String getLeaderboardId() {
+        return this.leaderboardId;
+    }
+
+    public void setLeaderboardId(String leaderboardId) {
+        this.leaderboardId = leaderboardId;
+    }
+
+    public SongInfo getSong() {
+        return this.song;
+    }
+
+    public void setSong(SongInfo song) {
+        this.song = song;
+    }
+
+    public ClanInfo getClan() {
+        return this.clan;
+    }
+
+    public void setClan(ClanInfo clan) {
+        this.clan = clan;
+    }
+
+    public List<Score> getScores() {
+        return this.scores;
+    }
+
+    public void setScores(List<Score> scores) {
+        this.scores = scores;
+    }
+
+    public static class Score {
+        @SerializedName(value="timeset")
+        private String timeset;
+        @SerializedName(value="player")
+        private PlayerInfo player;
+
+        public String getTimeset() {
+            return this.timeset;
+        }
+
+        public void setTimeset(String timeset) {
+            this.timeset = timeset;
+        }
+
+        public PlayerInfo getPlayer() {
+            return this.player;
+        }
+
+        public void setPlayer(PlayerInfo player) {
+            this.player = player;
+        }
+
+        public static class PlayerInfo {
+            @SerializedName(value="id")
+            private String playerId;
+            @SerializedName(value="name")
+            private String name;
+            @SerializedName(value="clans")
+            private List<ClanInfo> clans;
+
+            public String getPlayerId() {
+                return this.playerId;
+            }
+
+            public void setPlayerId(String playerId) {
+                this.playerId = playerId;
+            }
+
+            public String getName() {
+                return this.name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public List<ClanInfo> getClans() {
+                return this.clans;
+            }
+
+            public void setClans(List<ClanInfo> clans) {
+                this.clans = clans;
+            }
+        }
+    }
+
+    public static class ClanInfo {
+        @SerializedName(value="id")
+        private int clanId;
+        @SerializedName(value="name")
+        private String name;
+        @SerializedName(value="tag")
+        private String tag;
+        @SerializedName(value="icon")
+        private String icon;
+        @SerializedName(value="rank")
+        private int rank;
+
+        public int getClanId() {
+            return this.clanId;
+        }
+
+        public void setClanId(int clanId) {
+            this.clanId = clanId;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getTag() {
+            return this.tag;
+        }
+
+        public void setTag(String tag) {
+            this.tag = tag;
+        }
+
+        public String getIcon() {
+            return this.icon;
+        }
+
+        public void setIcon(String icon) {
+            this.icon = icon;
+        }
+
+        public int getRank() {
+            return this.rank;
+        }
+
+        public void setRank(int rank) {
+            this.rank = rank;
+        }
+    }
+
+    public static class SongInfo {
+        @SerializedName(value="id")
+        private String songId;
+        @SerializedName(value="name")
+        private String name;
+        @SerializedName(value="author")
+        private String author;
+        @SerializedName(value="mapper")
+        private String mapper;
+        @SerializedName(value="coverImage")
+        private String coverImage;
+        @SerializedName(value="bpm")
+        private float bpm;
+        @SerializedName(value="duration")
+        private int duration;
+
+        public String getSongId() {
+            return this.songId;
+        }
+
+        public void setSongId(String songId) {
+            this.songId = songId;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getAuthor() {
+            return this.author;
+        }
+
+        public void setAuthor(String author) {
+            this.author = author;
+        }
+
+        public String getMapper() {
+            return this.mapper;
+        }
+
+        public void setMapper(String mapper) {
+            this.mapper = mapper;
+        }
+
+        public String getCoverImage() {
+            return this.coverImage;
+        }
+
+        public void setCoverImage(String coverImage) {
+            this.coverImage = coverImage;
+        }
+
+        public float getBpm() {
+            return this.bpm;
+        }
+
+        public void setBpm(int bpm) {
+            this.bpm = bpm;
+        }
+
+        public int getDuration() {
+            return this.duration;
+        }
+
+        public void setDuration(int duration) {
+            this.duration = duration;
+        }
+    }
+}
+

--- a/src/main/java/bot/dto/clan/ProfileSettings.java
+++ b/src/main/java/bot/dto/clan/ProfileSettings.java
@@ -1,0 +1,137 @@
+package bot.dto.clan;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ProfileSettings {
+    @SerializedName(value="profileCover")
+    private Object profileCover;
+    @SerializedName(value="bio")
+    private Object bio;
+    @SerializedName(value="message")
+    private Object message;
+    @SerializedName(value="showBots")
+    private boolean showBots;
+    @SerializedName(value="saturation")
+    private float saturation;
+    @SerializedName(value="starredFriends")
+    private String starredFriends;
+    @SerializedName(value="profileAppearance")
+    private String profileAppearance;
+    @SerializedName(value="leftSaberColor")
+    private Object leftSaberColor;
+    @SerializedName(value="hue")
+    private int hue;
+    @SerializedName(value="id")
+    private int id;
+    @SerializedName(value="showAllRatings")
+    private boolean showAllRatings;
+    @SerializedName(value="rightSaberColor")
+    private Object rightSaberColor;
+    @SerializedName(value="effectName")
+    private String effectName;
+
+    public void setProfileCover(Object profileCover) {
+        this.profileCover = profileCover;
+    }
+
+    public Object getProfileCover() {
+        return this.profileCover;
+    }
+
+    public void setBio(Object bio) {
+        this.bio = bio;
+    }
+
+    public Object getBio() {
+        return this.bio;
+    }
+
+    public void setMessage(Object message) {
+        this.message = message;
+    }
+
+    public Object getMessage() {
+        return this.message;
+    }
+
+    public void setShowBots(boolean showBots) {
+        this.showBots = showBots;
+    }
+
+    public boolean isShowBots() {
+        return this.showBots;
+    }
+
+    public void setSaturation(int saturation) {
+        this.saturation = saturation;
+    }
+
+    public float getSaturation() {
+        return this.saturation;
+    }
+
+    public void setStarredFriends(String starredFriends) {
+        this.starredFriends = starredFriends;
+    }
+
+    public String getStarredFriends() {
+        return this.starredFriends;
+    }
+
+    public void setProfileAppearance(String profileAppearance) {
+        this.profileAppearance = profileAppearance;
+    }
+
+    public String getProfileAppearance() {
+        return this.profileAppearance;
+    }
+
+    public void setLeftSaberColor(Object leftSaberColor) {
+        this.leftSaberColor = leftSaberColor;
+    }
+
+    public Object getLeftSaberColor() {
+        return this.leftSaberColor;
+    }
+
+    public void setHue(int hue) {
+        this.hue = hue;
+    }
+
+    public int getHue() {
+        return this.hue;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return this.id;
+    }
+
+    public void setShowAllRatings(boolean showAllRatings) {
+        this.showAllRatings = showAllRatings;
+    }
+
+    public boolean isShowAllRatings() {
+        return this.showAllRatings;
+    }
+
+    public void setRightSaberColor(Object rightSaberColor) {
+        this.rightSaberColor = rightSaberColor;
+    }
+
+    public Object getRightSaberColor() {
+        return this.rightSaberColor;
+    }
+
+    public void setEffectName(String effectName) {
+        this.effectName = effectName;
+    }
+
+    public String getEffectName() {
+        return this.effectName;
+    }
+}
+

--- a/src/main/java/bot/main/BeatSaberBot.java
+++ b/src/main/java/bot/main/BeatSaberBot.java
@@ -4,6 +4,9 @@ import bot.api.BeatLeader;
 import bot.api.BeatSaver;
 import bot.api.ScoreSaber;
 import bot.commands.*;
+import bot.commands.beatleader.ClanRaid;
+import bot.commands.beatleader.ClanStats;
+import bot.commands.beatleader.ToConquer;
 import bot.commands.chart.PlayerChart;
 import bot.commands.chart.RadarStatsChart;
 import bot.commands.scoresaber.Qualified;
@@ -11,7 +14,11 @@ import bot.commands.scoresaber.Rank;
 import bot.commands.scoresaber.Ranked;
 import bot.db.DatabaseManager;
 import bot.dto.MessageEventDTO;
+import bot.dto.beatleader.ClanPlaylistFilter;
 import bot.dto.beatleader.player.BeatLeaderPlayer;
+import bot.main.beatleader.ClanMapsWatcher;
+import bot.main.beatleader.ClanPlayersWatcher;
+import bot.main.beatleader.ScheduledPlaylistGenerator;
 import bot.dto.player.DataBasePlayer;
 import bot.dto.player.PlayerSkills;
 import bot.dto.rankedmaps.RankedMaps;
@@ -86,6 +93,7 @@ public class BeatSaberBot extends ListenerAdapter {
             BeatSaberBot bot = new BeatSaberBot();
             bot.setupJDA();
             bot.setupLoggingAndLeaderboard();
+            bot.setupClanListeners();
             bot.registerSlashCommands();
         } catch (Exception e) {
             e.printStackTrace();
@@ -122,6 +130,15 @@ public class BeatSaberBot extends ListenerAdapter {
         LeaderboardWatcher watcher = new LeaderboardWatcher(db, ss, jda);
         watcher.createNewLeaderboardWatcher();
         watcher.start();
+    }
+
+    private void setupClanListeners() {
+        ClanPlayersWatcher watcherPlayers = new ClanPlayersWatcher("GER", db, jda);
+        watcherPlayers.startWatching();
+        ClanMapsWatcher watcherMaps = new ClanMapsWatcher("GER", db, jda);
+        watcherMaps.startWatching();
+        ScheduledPlaylistGenerator playlistGenerator = new ScheduledPlaylistGenerator();
+        playlistGenerator.start();
     }
 
     private void registerSlashCommands() {
@@ -290,6 +307,54 @@ public class BeatSaberBot extends ListenerAdapter {
                         Messages.sendMessage("Invalid number of parameters.", event);
                     }
                     break;
+                case "clanplaylist": {
+                    int count = 200;
+                    ClanPlaylistFilter filter = null;
+                    int index = 2;
+                    if (msgParts.size() > index && NumberUtils.isCreatable(msgParts.get(index))) {
+                        count = Integer.parseInt(msgParts.get(index++));
+                    }
+                    float accRating = 9999999.0f;
+                    float passRating = 9999999.0f;
+                    float techRating = 9999999.0f;
+                    boolean unplayed = false;
+                    while (index < msgParts.size()) {
+                        switch (msgParts.get(index).toLowerCase()) {
+                            case "acc":
+                                accRating = extractRating(msgParts, ++index);
+                                break;
+                            case "pass":
+                                passRating = extractRating(msgParts, ++index);
+                                break;
+                            case "tech":
+                                techRating = extractRating(msgParts, ++index);
+                                break;
+                            case "unplayed":
+                                unplayed = true;
+                                break;
+                        }
+                        ++index;
+                    }
+                    if (accRating != 9999999.0f || passRating != 9999999.0f || techRating != 9999999.0f || unplayed) {
+                        filter = new ClanPlaylistFilter(accRating, passRating, techRating, unplayed);
+                    }
+                    new ToConquer().sendToConquerPlaylist(count, filter, commandPlayer, event);
+                    break;
+                }
+                case "clanraid": {
+                    String clanTag = msgParts.size() > 2 ? msgParts.get(2) : null;
+                    if (clanTag == null) {
+                        Messages.sendMessage("Missing clan tag param", event);
+                        return;
+                    }
+                    clanTag = clanTag.toUpperCase();
+                    new ClanRaid().sendClanRaidPlaylist(clanTag, event);
+                    break;
+                }
+                case "clanstats": {
+                    new ClanStats(db).executeClanStatsCommand(event);
+                    break;
+                }
                 case "randommeme":
                     new RandomMeme().sendRandomMeme(channel);
                     break;
@@ -439,6 +504,13 @@ public class BeatSaberBot extends ListenerAdapter {
             return Integer.parseInt(msgParts.get(2));
         }
         return 1;
+    }
+
+    private float extractRating(List<String> msgParts, int index) {
+        if (index < msgParts.size() && NumberUtils.isCreatable(msgParts.get(index))) {
+            return Float.parseFloat(msgParts.get(index));
+        }
+        return 0.0f;
     }
 
     private void fetchRankedMapsIfNonExistent(TextChannel channel) {

--- a/src/main/java/bot/main/BotConstants.java
+++ b/src/main/java/bot/main/BotConstants.java
@@ -29,8 +29,15 @@ public class BotConstants {
     public static final long patreonChadSupporterRoleId = Long.parseLong(System.getenv("patreon_chad_role_id"));
 
     public static final long bsgOutputChannelId = Long.parseLong(System.getenv("bsg_channel_id"));
+    public static final long bsgClanChannelId = Long.parseLong(System.getenv("bsg_clan_channel_id"));
 
     public static final String bsgImage = "https://i.imgur.com/PlKkLyM.png";
+
+    // BeatLeader clan
+    public static final String clanConquerPlaylistSyncUrl = "https://anti.link/playlists/BSG_Conquer_Maps.json";
+    public static final String playlistImageRaidBsgUrl = "https://i.imgur.com/2V038wD.png";
+    public static final String playlistImageBsg = getImageBase64("bsg.png");
+    public static final String filterPlaylistImageBsg = getImageBase64("bsgFilter.png");
 
     // Role milestones
     public static final Integer[] bsgCountryRankMilestones = {1, 5, 10, 25, 50, 75, 100, 200};

--- a/src/main/java/bot/main/beatleader/ClanMapsWatcher.java
+++ b/src/main/java/bot/main/beatleader/ClanMapsWatcher.java
@@ -1,0 +1,128 @@
+package bot.main.beatleader;
+
+import bot.api.BeatLeader;
+import bot.api.NodeBackend;
+import bot.db.DatabaseManager;
+import bot.dto.clan.ClanMap;
+import bot.dto.clan.LeaderboardInfo;
+import bot.main.BotConstants;
+import bot.utils.DiscordLogger;
+import bot.utils.Format;
+import bot.utils.Messages;
+import java.awt.Color;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+public class ClanMapsWatcher {
+    private final NodeBackend backend = new NodeBackend();
+    private final BeatLeader bl = new BeatLeader();
+    private final DatabaseManager dbManager;
+    private final String clanId;
+    private List<ClanMap> lastCheckedClanMaps;
+    TextChannel bsgMapsChannel;
+
+    public ClanMapsWatcher(String clanId, DatabaseManager dbManager, JDA jda) {
+        this.dbManager = dbManager;
+        this.clanId = clanId;
+        this.lastCheckedClanMaps = null;
+        this.bsgMapsChannel = jda.getTextChannelById(BotConstants.bsgClanChannelId);
+    }
+
+    public void startWatching() {
+        ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
+        service.scheduleAtFixedRate(this::checkForMapChanges, 0L, 15L, TimeUnit.MINUTES);
+    }
+
+    private void checkForMapChanges() {
+        DiscordLogger.sendLogInChannel("\ud83d\udfe1 Starting Clan Maps Watcher... [" + Format.oneDigitZero(LocalTime.now().getHour()) + ":" + Format.oneDigitZero(LocalTime.now().getMinute()) + "]", "foaa-refresh");
+        try {
+            List<ClanMap> currentClanMaps = this.backend.getClanMaps(this.clanId, "tohold", 100);
+            if (currentClanMaps == null) {
+                DiscordLogger.sendLogInChannel("\ud83d\udd34 Error while trying to get current clan maps!", "http-errors");
+                return;
+            }
+            if (this.lastCheckedClanMaps == null) {
+                this.lastCheckedClanMaps = currentClanMaps;
+                DiscordLogger.sendLogInChannel("\ud83d\udfe2 Initial Clan Maps Watcher Finished!", "foaa-refresh");
+                return;
+            }
+            List<ClanMap> newCaptures = currentClanMaps.stream().filter(map -> this.lastCheckedClanMaps.stream().noneMatch(storedMap -> storedMap.getLeaderboardId().equals(map.getLeaderboardId()))).collect(Collectors.toList());
+            List<ClanMap> lostMaps = this.lastCheckedClanMaps.stream().filter(storedMap -> currentClanMaps.stream().noneMatch(map -> map.getLeaderboardId().equals(storedMap.getLeaderboardId()))).collect(Collectors.toList());
+            for (ClanMap newCapture : newCaptures) {
+                LeaderboardInfo leaderboardInfo = this.bl.getLeaderboardInfo(newCapture.getLeaderboardId());
+                LeaderboardInfo.Score.PlayerInfo capturingPlayer = null;
+                if (leaderboardInfo != null && leaderboardInfo.getScores() != null) {
+                    capturingPlayer = this.findCapturingPlayer(leaderboardInfo);
+                }
+                this.sendMapNotification(newCapture, true, null, capturingPlayer);
+            }
+            for (ClanMap lostMap : lostMaps) {
+                this.processLostMap(lostMap);
+            }
+            this.lastCheckedClanMaps = currentClanMaps;
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+        DiscordLogger.sendLogInChannel("\ud83d\udfe2 Clan Maps Watcher Finished!", "foaa-refresh");
+    }
+
+    private void processLostMap(ClanMap lostMap) {
+        LeaderboardInfo leaderboardInfo = this.bl.getLeaderboardInfo(lostMap.getLeaderboardId());
+        if (leaderboardInfo != null && leaderboardInfo.getClan() != null && !leaderboardInfo.getClan().getTag().equalsIgnoreCase(this.clanId)) {
+            LeaderboardInfo.Score.PlayerInfo capturingPlayer = this.findCapturingPlayer(leaderboardInfo);
+            this.sendMapNotification(lostMap, false, leaderboardInfo.getClan().getTag(), capturingPlayer);
+        } else {
+            this.sendMapNotification(lostMap, false, null, null);
+        }
+    }
+
+    private void sendMapNotification(ClanMap map, boolean isNewCapture, String conqueringClanTag, LeaderboardInfo.Score.PlayerInfo player) {
+        Color color;
+        String message;
+        String title;
+        Object playerCaptureMessage = "";
+        if (isNewCapture) {
+            if (player != null) {
+                long playerId = Long.parseLong(player.getPlayerId());
+                this.dbManager.incrementCaptureCount(playerId);
+                int captureCount = this.dbManager.getCaptureCount(playerId);
+                String playerUrl = "https://www.beatleader.xyz/u/" + player.getPlayerId();
+                playerCaptureMessage = "\nCaptured by **[" + player.getName() + "](" + playerUrl + ")**! :black_heart: :heart: :yellow_heart:\n" + Format.underline(player.getName() + " capture count:") + Format.bold(" " + captureCount);
+            }
+            title = "New Map Capture! :map:";
+            message = String.format("**%s** has been captured on **%s** difficulty. Great job team! \ud83d\udc4f\n%s", map.getSongName(), map.getDifficultyName(), playerCaptureMessage);
+            color = Color.GREEN;
+        } else {
+            if (player != null) {
+                String playerUrl = "https://www.beatleader.xyz/u/" + player.getPlayerId();
+                playerCaptureMessage = "\nStolen by **[" + player.getName() + "](" + playerUrl + ")**! ";
+            }
+            title = "Map Lost... :pensive::wilted_rose:";
+            message = conqueringClanTag != null ? String.format("We've lost **%s** on **%s** difficulty to **%s** clan.%s\nTime to reclaim it!", map.getSongName(), map.getDifficultyName(), conqueringClanTag, playerCaptureMessage) : String.format("We've lost **%s** on **%s** difficulty.\nTime to reclaim it!", map.getSongName(), map.getDifficultyName());
+            color = Color.RED;
+        }
+        Messages.sendBsgRankMessage(title, message, "https://www.beatleader.xyz/leaderboard/global/" + map.getLeaderboardId(), color, map.getSongCover(), (MessageChannel)this.bsgMapsChannel);
+    }
+
+    private LeaderboardInfo.Score.PlayerInfo findCapturingPlayer(LeaderboardInfo leaderboardInfo) {
+        LocalDateTime twentyMinutesAgo = LocalDateTime.now(ZoneId.systemDefault()).minus(20L, ChronoUnit.MINUTES);
+        return leaderboardInfo.getScores().stream().filter(score -> score.getPlayer() != null && score.getPlayer().getClans() != null).filter(score -> {
+            LocalDateTime scoreTime = LocalDateTime.ofInstant(Instant.ofEpochSecond(Long.parseLong(score.getTimeset())), ZoneId.systemDefault());
+            return scoreTime.isAfter(twentyMinutesAgo);
+        }).max(Comparator.comparing(score -> Long.parseLong(score.getTimeset()))).map(LeaderboardInfo.Score::getPlayer).orElse(null);
+    }
+}
+

--- a/src/main/java/bot/main/beatleader/ClanPlayersWatcher.java
+++ b/src/main/java/bot/main/beatleader/ClanPlayersWatcher.java
@@ -1,0 +1,123 @@
+package bot.main.beatleader;
+
+import bot.api.NodeBackend;
+import bot.db.DatabaseManager;
+import bot.dto.clan.ClanPlayer;
+import bot.dto.player.DataBasePlayer;
+import bot.main.BotConstants;
+import bot.utils.DiscordLogger;
+import bot.utils.Format;
+import bot.utils.Messages;
+import java.awt.Color;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+public class ClanPlayersWatcher {
+    private final NodeBackend backend = new NodeBackend();
+    private final JDA jda;
+    private final DatabaseManager db;
+    private final String clanId;
+    private List<ClanPlayer> lastCheckedClanPlayers;
+    List<DataBasePlayer> dbPlayers;
+    TextChannel bsgClanChannel;
+
+    public ClanPlayersWatcher(String clanId, DatabaseManager db, JDA jda) {
+        this.jda = jda;
+        this.db = db;
+        this.clanId = clanId;
+        this.lastCheckedClanPlayers = null;
+        this.dbPlayers = new ArrayList<DataBasePlayer>();
+        this.bsgClanChannel = jda.getTextChannelById(BotConstants.bsgClanChannelId);
+    }
+
+    public void startWatching() {
+        ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
+        service.scheduleAtFixedRate(this::checkForNewClanPlayers, 0L, 15L, TimeUnit.MINUTES);
+    }
+
+    private void checkForNewClanPlayers() {
+        DiscordLogger.sendLogInChannel("\ud83d\udfe1 Starting Clan Role Refresh... [" + Format.oneDigitZero(LocalTime.now().getHour()) + ":" + Format.oneDigitZero(LocalTime.now().getMinute()) + "]", "foaa-refresh");
+        this.db.connectToDatabase();
+        this.dbPlayers = this.db.getAllStoredPlayers();
+        try {
+            String profileUrl;
+            List<ClanPlayer> currentClanPlayers = this.backend.getClanPlayers(this.clanId);
+            if (currentClanPlayers == null) {
+                DiscordLogger.sendLogInChannel("\ud83d\udd34 Error while trying to get current BL clan members!", "http-errors");
+                return;
+            }
+            if (this.lastCheckedClanPlayers == null) {
+                for (ClanPlayer player2 : currentClanPlayers) {
+                    this.assignDiscordRole(player2);
+                }
+                this.lastCheckedClanPlayers = currentClanPlayers;
+                DiscordLogger.sendLogInChannel("\ud83d\udfe2 Initial Clan Role Refresh Finished!", "foaa-refresh");
+                return;
+            }
+            List<ClanPlayer> newPlayers = currentClanPlayers.stream().filter(player -> this.lastCheckedClanPlayers.stream().noneMatch(storedPlayer -> storedPlayer.getId().equals(player.getId()))).collect(Collectors.toList());
+            List<ClanPlayer> leftPlayers = this.lastCheckedClanPlayers.stream().filter(storedPlayer -> currentClanPlayers.stream().noneMatch(player -> player.getId().equals(storedPlayer.getId()))).collect(Collectors.toList());
+            for (ClanPlayer newPlayer : newPlayers) {
+                String welcomeTitle = ":speaking_head: New Member Alert! :speaking_head:";
+                String welcomeMessage = String.format("Welcome %s to the BSG Clan!\nGlad to have you on board.\n:black_heart: :heart: :yellow_heart:", Format.bold(newPlayer.getName()));
+                profileUrl = "https://www.beatleader.xyz/u/" + newPlayer.getId();
+                Color welcomeColor = Color.CYAN;
+                Messages.sendBsgRankMessage(welcomeTitle, welcomeMessage, profileUrl, welcomeColor, newPlayer.getAvatar(), (MessageChannel)this.bsgClanChannel);
+                this.assignDiscordRole(newPlayer);
+            }
+            for (ClanPlayer leftPlayer : leftPlayers) {
+                String farewellTitle = "Member Departure \ud83d\udc4b\ud83c\udffb";
+                String farewellMessage = String.format("%s has left the BSG Clan.\nBest wishes!", Format.bold(leftPlayer.getName()));
+                profileUrl = "https://www.beatleader.xyz/u/" + leftPlayer.getId();
+                Color farewellColor = Color.ORANGE;
+                Messages.sendBsgRankMessage(farewellTitle, farewellMessage, profileUrl, farewellColor, leftPlayer.getAvatar(), (MessageChannel)this.bsgClanChannel);
+                this.removeDiscordRole(leftPlayer);
+            }
+            this.lastCheckedClanPlayers = currentClanPlayers;
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+        DiscordLogger.sendLogInChannel("\ud83d\udfe2 Clan Role Refresh Finished!", "foaa-refresh");
+    }
+
+    private void assignDiscordRole(ClanPlayer player) {
+        Member member = this.findMember(player.getId());
+        if (member != null) {
+            Role roleToAssign = (Role)member.getGuild().getRolesByName("clan member", true).get(0);
+            member.getGuild().addRoleToMember(member, roleToAssign).queue();
+        }
+    }
+
+    private void removeDiscordRole(ClanPlayer player) {
+        Member member = this.findMember(player.getId());
+        if (member != null) {
+            Role roleToRemove = (Role)member.getGuild().getRolesByName("clan member", true).get(0);
+            member.getGuild().removeRoleFromMember(member, roleToRemove).queue();
+        }
+    }
+
+    private Member findMember(String playerId) {
+        DataBasePlayer dbPlayer = this.dbPlayers.stream().filter(player -> playerId.equals(player.getId())).findFirst().orElse(null);
+        if (dbPlayer == null) {
+            return null;
+        }
+        long discordId = dbPlayer.getDiscordUserId();
+        Guild bsgGuild = this.jda.getGuildById(BotConstants.bsgServerId);
+        if (bsgGuild != null) {
+            return bsgGuild.getMemberById(discordId);
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/bot/main/beatleader/ScheduledPlaylistGenerator.java
+++ b/src/main/java/bot/main/beatleader/ScheduledPlaylistGenerator.java
@@ -30,6 +30,10 @@ public class ScheduledPlaylistGenerator {
             String playlistTitle = "GER Conquer Maps - " + formattedDateTime;
             String filePath = System.getenv("clan_playlist_path") + "BSG_Conquer_Maps.json";
             List<ClanMap> maps = this.backend.getClanMaps("GER", "toconquer", 10);
+            if (maps == null) {
+                DiscordLogger.sendLogInChannel("Could not fetch clan maps; skipping playlist generation this cycle.", "errors");
+                return;
+            }
             PlaylistGenerator.generatePlaylistFile(maps, playlistTitle, BotConstants.playlistImageBsg, filePath, "bsgconquer", "https://anti.link/playlists/BSG_Conquer_Maps.json");
             DiscordLogger.sendLogInChannel("\ud83d\udd35 Updated clan sync playlist", "foaa-refresh");
         }

--- a/src/main/java/bot/main/beatleader/ScheduledPlaylistGenerator.java
+++ b/src/main/java/bot/main/beatleader/ScheduledPlaylistGenerator.java
@@ -1,0 +1,42 @@
+package bot.main.beatleader;
+
+import bot.api.NodeBackend;
+import bot.commands.beatleader.PlaylistGenerator;
+import bot.dto.clan.ClanMap;
+import bot.main.BotConstants;
+import bot.utils.DiscordLogger;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class ScheduledPlaylistGenerator {
+    private final NodeBackend backend = new NodeBackend();
+
+    public void start() {
+        ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
+        service.scheduleAtFixedRate(this::generatePlaylist, 3L, 15L, TimeUnit.MINUTES);
+    }
+
+    private void generatePlaylist() {
+        if (System.getenv("clan_playlist_path") == null) {
+            DiscordLogger.sendLogInChannel("CLAN_PLAYLIST_PATH NOT SET", "errors");
+            return;
+        }
+        try {
+            String formattedDateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("dd.MM. HH:mm"));
+            String playlistTitle = "GER Conquer Maps - " + formattedDateTime;
+            String filePath = System.getenv("clan_playlist_path") + "BSG_Conquer_Maps.json";
+            List<ClanMap> maps = this.backend.getClanMaps("GER", "toconquer", 10);
+            PlaylistGenerator.generatePlaylistFile(maps, playlistTitle, BotConstants.playlistImageBsg, filePath, "bsgconquer", "https://anti.link/playlists/BSG_Conquer_Maps.json");
+            DiscordLogger.sendLogInChannel("\ud83d\udd35 Updated clan sync playlist", "foaa-refresh");
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            DiscordLogger.sendLogInChannel(e.toString(), "errors");
+        }
+    }
+}
+


### PR DESCRIPTION
## What this does

The deployed server jar contains a complete **BeatLeader Clan** feature that was never in the repo. This PR ports it **verbatim from the decompiled live build** so the repo matches what is actually running on the server. (The repo was otherwise an exact match for the deployed build minus this feature.)

### Text commands (`ru ...`)
- `clanplaylist [count] [acc N] [pass N] [tech N] [unplayed]` → `ToConquer`: builds a "maps to conquer" playlist with optional rating filters
- `clanraid <TAG>` → `ClanRaid`: raid playlist vs a target clan
- `clanstats` → `ClanStats`: capture-count leaderboard embed

### Background watchers (15-min cycle, started in `BeatSaberBot.setupClanListeners`)
- `ClanPlayersWatcher` — clan roster diff → welcome/farewell messages + Discord role sync
- `ClanMapsWatcher` — map capture/loss notifications + increments capture counts
- `ScheduledPlaylistGenerator` — regenerates `BSG_Conquer_Maps.json` to disk

## Files
- **20 new classes**: `bot.commands.beatleader.*`, `bot.main.beatleader.*`, `bot.dto.clan.*`, `bot.dto.beatleader.clanranking.*`, `bot.dto.beatleader.playerscore.*`, `ClanPlaylistFilter`, `accgraph.PlayerBLRankedScore` — copied from the deployed build.
- **6 shared classes extended** with clan deltas only (repo conventions preserved — e.g. URL helpers use the existing `BACKEND_URL`/`BL_PRE_URL` constants so they stay environment-correct):
  - `ApiConstants` — clan + BeatLeader clan-ranking/leaderboard/accgraph URL helpers
  - `NodeBackend` — `getClanPlayers`, `getClanMaps`
  - `BeatLeader` — `getLeaderboardInfo`, `getLeaderboardClanRanking`, `getPlayerScore`, `getAllPlayerRankedScores`
  - `DatabaseManager` — `clancapturecounts` collection + `getPlayerById(long)`, `incrementCaptureCount`, `getCaptureCounts`, `getCaptureCount`
  - `BotConstants` — `bsgClanChannelId` + clan playlist image/URL constants
  - `BeatSaberBot` — imports, `setupClanListeners()`, 3 switch cases, `extractRating()` helper

## Required to run
- **Env var** `bsg_clan_channel_id` (Discord channel for clan notifications). **Loaded eagerly in `BotConstants`** — must be set or the bot won't boot.
- **Env var** `clan_playlist_path` (optional; output dir for the generated playlist — read lazily, safe if unset).
- **Mongo collection** `clancapturecounts` (auto-created on first write).
- **Resource images** `bsg.png` and `bsgFilter.png` in `src/main/resources/` — these are `.gitignore`d like all the other images (`playlistCover.png`, etc.), so they're not in this PR; they already exist on the deployed server.

## Testing
Whole repo compiles cleanly (`javac`, Java 8, 161 source files) against the deployed bot's bundled dependencies. All required deps (`org.json`, `mongo-java-driver`, JDA, gson) are already in `pom.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
