### PR TITLE
Fix correctness bugs found in code review sweep

### DIFF
--- a/src/main/java/bot/api/AccSaber.java
+++ b/src/main/java/bot/api/AccSaber.java
@@ -28,7 +28,10 @@ public class AccSaber {
         List<PlayerScore> recentScores = getPlayerScores(url);
         if (recentScores != null) {
             int offset = pageNr - 1;
-            return recentScores.subList(8 * offset, 8 + 8 * offset);
+            // Clamp bounds: requesting page 6+ used to exceed the (max ~40) list size and throw.
+            int from = Math.min(8 * offset, recentScores.size());
+            int to = Math.min(8 + 8 * offset, recentScores.size());
+            return recentScores.subList(from, to);
         }
         return Collections.emptyList();
     }
@@ -39,7 +42,10 @@ public class AccSaber {
         List<PlayerScore> recentScores = getPlayerScores(url);
         if (recentScores != null && recentScores.size() > 0) {
             int offset = pageNr - 1;
-            return recentScores.subList(8 * offset, 8 + 8 * offset);
+            // Clamp bounds: requesting page 6+ used to exceed the (max ~40) list size and throw.
+            int from = Math.min(8 * offset, recentScores.size());
+            int to = Math.min(8 + 8 * offset, recentScores.size());
+            return recentScores.subList(from, to);
         }
         return Collections.emptyList();
     }

--- a/src/main/java/bot/api/ApiConstants.java
+++ b/src/main/java/bot/api/ApiConstants.java
@@ -70,7 +70,6 @@ public class ApiConstants {
         return String.format(ACC_PRE_URL + ACC_SCORES_URL, playerId, pageNr, "ap");
     }
     public static String getAccSaberRecentScoresURL(String playerId, int pageNr) {
-        System.out.println(String.format(ACC_PRE_URL + ACC_SCORES_URL, playerId, pageNr, "timeSet"));
         return String.format(ACC_PRE_URL + ACC_SCORES_URL, playerId, pageNr, "timeSet");
     }
     public static final String ACC_USER_URL = "/profile/%s/overall/scores";

--- a/src/main/java/bot/api/ScoreSaber.java
+++ b/src/main/java/bot/api/ScoreSaber.java
@@ -92,6 +92,10 @@ public class ScoreSaber {
             }
             String leaderboardUrl = getLeaderboardApiUrl(i, countryCode);
             JsonObject response = http.fetchJsonObject(leaderboardUrl);
+            if (response == null) {
+                // A single failed/rate-limited page request used to NPE here and abort the whole scan.
+                return null;
+            }
             JsonArray responsePlayerList = response.getAsJsonArray("players");
             Type listType = new TypeToken<List<ScoreSaberPlayer>>() {}.getType();
             entries.addAll(gson.fromJson(responsePlayerList, listType));

--- a/src/main/java/bot/commands/scoresaber/Rank.java
+++ b/src/main/java/bot/commands/scoresaber/Rank.java
@@ -66,8 +66,14 @@ public class Rank {
             resultMessage += toEntryString(leaderboardEntries.get(playerIndex - 1), playerPp, leaderboardType);
         }
         resultMessage += toEntryString(playerEntry, -1, leaderboardType);
-        resultMessage += toEntryString(leaderboardEntries.get(playerIndex + 1), playerPp, leaderboardType);
-        resultMessage += toEntryString(leaderboardEntries.get(playerIndex + 2), playerPp, leaderboardType);
+        // Guard the upper bound like the lower bound above: a player at/near the end of the
+        // returned slice used to throw IndexOutOfBoundsException.
+        if (playerIndex + 1 < leaderboardEntries.size()) {
+            resultMessage += toEntryString(leaderboardEntries.get(playerIndex + 1), playerPp, leaderboardType);
+        }
+        if (playerIndex + 2 < leaderboardEntries.size()) {
+            resultMessage += toEntryString(leaderboardEntries.get(playerIndex + 2), playerPp, leaderboardType);
+        }
 
         String title = "";
         switch (leaderboardType) {

--- a/src/main/java/bot/db/DatabaseManager.java
+++ b/src/main/java/bot/db/DatabaseManager.java
@@ -129,9 +129,12 @@ public class DatabaseManager {
         Document document = database.getCollection("skills").find(Filters.eq("discord_user_id", idLong)).first();
         String updateField = "skills." + skill;
         if (document != null) {
-            database.getCollection("skills").updateOne(Filters.eq("discord_id", idLong), new Document("$set", new Document(updateField, newValue)));
+            // Was Filters.eq("discord_id", ...): the lookup above and the insert below use
+            // "discord_user_id", so updates never matched and skills silently failed to persist
+            // (re-inserting duplicates each time, and "ru stand" never finding them).
+            database.getCollection("skills").updateOne(Filters.eq("discord_user_id", idLong), new Document("$set", new Document(updateField, newValue)));
         } else {
-            Document newSkill = new Document("discord_id", idLong)
+            Document newSkill = new Document("discord_user_id", idLong)
                     .append("player_name", getPlayerByDiscordId(idLong).getName())
                     .append("skills", new Document(skill, newValue));
             database.getCollection("skills").insertOne(newSkill);

--- a/src/main/java/bot/dto/player/DataBasePlayer.java
+++ b/src/main/java/bot/dto/player/DataBasePlayer.java
@@ -164,7 +164,7 @@ public class DataBasePlayer implements Serializable, LeaderboardServicePlayer {
                 .append("player_discord_user_id", discordUserId)
                 .append("player_historyValues", historyValues)
                 .append("player_histories", histories)
-                .append("player_scoreStats", scoreStats.toDocument())
+                .append("player_scoreStats", scoreStats == null ? null : scoreStats.toDocument())
                 .append("user_customAccGridImage", customAccGridImage);
     }
 

--- a/src/main/java/bot/main/LeaderboardWatcher.java
+++ b/src/main/java/bot/main/LeaderboardWatcher.java
@@ -138,7 +138,9 @@ public class LeaderboardWatcher {
             if (playerHasJustWentInactive) {
                 String inactiveMessage = Format.underline(Format.bold(updatedPlayer.getName())) + " just went inactive! (Previously " + Format.bold("#" + oldPlayer.getCountryRank() + " DE)");
                 Messages.sendBsgRankMessage(inactiveMessage, "F", updatedPlayer.getProfileURL(), Color.orange, updatedPlayer.getProfilePicture(), bsgOutput);
-                return;
+                // Was `return;`, which aborted the whole loop on the first inactive player,
+                // skipping every remaining DE player's role/snipe update for that cycle.
+                continue;
             }
             if (playerImproved && !isInactive) {
                 //Send message (only improvement)


### PR DESCRIPTION
## Summary

Independent correctness fixes found during a code-review sweep. These are **pre-existing bugs** in `master`, unrelated to the role-flapping (#38), rate-limit (#39), and clan (#40) PRs. Each is small and self-contained.

| # | Severity | File | Bug |
|---|----------|------|-----|
| 1 | **High** | `LeaderboardWatcher` | The "just went inactive" branch did `return` inside the per-player loop, so the **first** DE player who went inactive aborted the whole refresh — every remaining player's role/snipe/improvement update was skipped that cycle. → `continue` |
| 2 | **High** | `DatabaseManager.setSkill` | Read/insert used `discord_user_id` but the update filter + inserted doc used `discord_id`. Skill updates never matched and never showed in `ru stand`, re-inserting a duplicate every time. → consistent field name |
| 3 | **High** | `ScoreSaber.findLeaderboardEntriesAroundPlayer` | No null-check on the paged response; one failed/rate-limited page NPE'd and aborted the whole scan (`ru rank`/`ru localrank`). → return null on null response |
| 4 | Medium | `AccSaber.get{Top,Recent}ScoresByPlayerIdAndPage` | `subList(8*offset, 8+8*offset)` had no upper-bound clamp → `IndexOutOfBounds` for page 6+. → clamp to list size |
| 5 | Medium | `Rank` | The two "following player" rows were fetched without an upper-bound check (the preceding rows *were* guarded) → `IndexOutOfBounds` when the player is at/near the end of the slice. → bounds checks |
| 6 | Medium | `DataBasePlayer.toDocument` | Unconditional `scoreStats.toDocument()` NPE'd on save; the watcher forces an update precisely when `scoreStats` is null. → null guard |
| 7 | Low | `ApiConstants` | Stray debug `System.out.println` in `getAccSaberRecentScoresURL`. → removed |

## Testing
Whole repo compiles cleanly (`javac`, Java 8, 141 files) against the deployed bot's bundled dependencies. No API/DB/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
